### PR TITLE
Sysroot for Linux x86_64 with GCC 8.4 was patched by bug fix

### DIFF
--- a/cc_toolchain/deps/cc_toolchain_deps.bzl
+++ b/cc_toolchain/deps/cc_toolchain_deps.bzl
@@ -20,10 +20,10 @@ def cc_toolchain_deps():
         # Produce wheels with tag manylinux_2_27_x86_64
         http_archive(
             name = "sysroot_linux_x86_64",
-            sha256 = "5f62ca2978b4243cfca5d3798e78f4ced50b07bbc7ed1299ccbb8a715931304c",
-            urls = ["https://storage.googleapis.com/ml-sysroot-testing/ubuntu18_x86_64_sysroot.tar.xz"],
+            sha256 = "02f418783479fbf612701e20ff9f48c1713b60545ec090da3855e77b9e27881a",
+            urls = ["https://storage.googleapis.com/ml-sysroot-testing/ubuntu18_x86_64_sysroot_gcc8_patched.tar.xz"],
             build_file = Label("//cc_toolchain/config:sysroot_ubuntu18_x86_64.BUILD"),
-            strip_prefix = "ubuntu18_x86_64_sysroot",
+            strip_prefix = "ubuntu18_x86_64_sysroot_gcc8_patched",
         )
 
     if "sysroot_linux_aarch64" not in native.existing_rules():


### PR DESCRIPTION
Bug fix for issue https://cplusplus.github.io/LWG/issue3041 was added to GCC 8.4.