### PR TITLE
Integrate NVIDIA parallel programming interface (NVSHMEM) from XLA project 

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -19,7 +19,6 @@ workspace(
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("//cc_toolchain/deps:cc_toolchain_deps.bzl", "cc_toolchain_deps")
 
 ### rules_cc
 http_archive(
@@ -163,22 +162,26 @@ load(
 
 cuda_configure(name = "local_config_cuda")
 
+##############################################################
+# NCCL configuration
+load(
+    "@rules_ml_toolchain//third_party/nccl/hermetic:nccl_redist_init_repository.bzl",
+    "nccl_redist_init_repository",
+)
+
+nccl_redist_init_repository()
+
+load(
+    "@rules_ml_toolchain//third_party/nccl/hermetic:nccl_configure.bzl",
+    "nccl_configure",
+)
+
+nccl_configure(name = "local_config_nccl")
+
+##############################################################
+# Hermetic toolchain configuration
+load("//cc_toolchain/deps:cc_toolchain_deps.bzl", "cc_toolchain_deps")
+
 cc_toolchain_deps()
 
 register_toolchains("//cc_toolchain/...")
-
-##############################################################
-# NCCL configuration
-#load(
-#    "@rules_ml_toolchain//nccl/hermetic:nccl_redist_init_repository.bzl",
-#    "nccl_redist_init_repository",
-#)
-
-#nccl_redist_init_repository()
-
-#load(
-#    "@rules_ml_toolchain//nccl/hermetic:nccl_configure.bzl",
-#    "nccl_configure",
-#)
-
-#nccl_configure(name = "local_config_nccl")

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -179,6 +179,36 @@ load(
 nccl_configure(name = "local_config_nccl")
 
 ##############################################################
+# NVSHMEM configuration
+
+load(
+    "@rules_ml_toolchain//third_party/nvshmem/hermetic:nvshmem_json_init_repository.bzl",
+    "nvshmem_json_init_repository",
+)
+
+nvshmem_json_init_repository()
+
+load(
+    "@nvshmem_redist_json//:distributions.bzl",
+    "NVSHMEM_REDISTRIBUTIONS",
+)
+load(
+    "@rules_ml_toolchain//third_party/nvshmem/hermetic:nvshmem_redist_init_repository.bzl",
+    "nvshmem_redist_init_repository",
+)
+
+nvshmem_redist_init_repository(
+    nvshmem_redistributions = NVSHMEM_REDISTRIBUTIONS,
+)
+
+load(
+    "@rules_ml_toolchain//third_party/nvshmem/hermetic:nvshmem_configure.bzl",
+    "nvshmem_configure",
+)
+
+nvshmem_configure(name = "local_config_nvshmem")
+
+##############################################################
 # Hermetic toolchain configuration
 load("//cc_toolchain/deps:cc_toolchain_deps.bzl", "cc_toolchain_deps")
 

--- a/cc_toolchain/deps/cc_toolchain_deps.bzl
+++ b/cc_toolchain/deps/cc_toolchain_deps.bzl
@@ -20,10 +20,10 @@ def cc_toolchain_deps():
         # Produce wheels with tag manylinux_2_27_x86_64
         http_archive(
             name = "sysroot_linux_x86_64",
-            sha256 = "5f62ca2978b4243cfca5d3798e78f4ced50b07bbc7ed1299ccbb8a715931304c",
-            urls = ["https://storage.googleapis.com/ml-sysroot-testing/ubuntu18_x86_64_sysroot.tar.xz"],
+            sha256 = "02f418783479fbf612701e20ff9f48c1713b60545ec090da3855e77b9e27881a",
+            urls = ["https://storage.googleapis.com/ml-sysroot-testing/ubuntu18_x86_64_sysroot_gcc8_patched.tar.xz"],
             build_file = Label("//cc_toolchain/config:sysroot_ubuntu18_x86_64.BUILD"),
-            strip_prefix = "ubuntu18_x86_64_sysroot",
+            strip_prefix = "ubuntu18_x86_64_sysroot_gcc8_patched",
         )
 
     if "sysroot_linux_aarch64" not in native.existing_rules():

--- a/third_party/gpus/cuda/hermetic/BUILD.tpl
+++ b/third_party/gpus/cuda/hermetic/BUILD.tpl
@@ -308,3 +308,18 @@ cc_library(
     # to make bazel query happy.
     name = "nvptxcompiler",
 )
+
+alias(
+    name = "runtime_fatbinary",
+    actual = "@cuda_nvcc//:fatbinary",
+)
+
+alias(
+    name = "runtime_nvlink",
+    actual = "@cuda_nvcc//:nvlink",
+)
+
+alias(
+    name = "runtime_ptxas",
+    actual = "@cuda_nvcc//:ptxas",
+)

--- a/third_party/gpus/cuda/hermetic/cuda_configure.bzl
+++ b/third_party/gpus/cuda/hermetic/cuda_configure.bzl
@@ -47,6 +47,7 @@ load("@cuda_curand//:version.bzl", _curand_version = "VERSION")
 load("@cuda_cusolver//:version.bzl", _cusolver_version = "VERSION")
 load("@cuda_cusparse//:version.bzl", _cusparse_version = "VERSION")
 load("@cuda_nvcc//:version.bzl", _nvcc_version = "VERSION")
+load("@cuda_nvdisasm//:version.bzl", _nvdisasm_version = "VERSION")
 load("@cuda_nvjitlink//:version.bzl", _nvjitlink_version = "VERSION")
 load("@cuda_nvml//:version.bzl", _nvml_version = "VERSION")
 load("@cuda_nvtx//:version.bzl", _nvtx_version = "VERSION")
@@ -156,6 +157,7 @@ def _get_cpu_compiler(repository_ctx):
 
     cc = _find_cc(repository_ctx)
     if not _is_clang(cc):
+        # We support builds by clang only
         return "clang"
 
     return "clang {}".format(_get_clang_major_version(repository_ctx, cc))
@@ -348,6 +350,7 @@ def _get_cuda_config(repository_ctx):
         cudnn_version = _cudnn_version,
         cccl_version = _cccl_version,
         nvcc_version = _nvcc_version,
+        nvdisasm_version = _nvdisasm_version,
         nvjitlink_version = _nvjitlink_version,
         nvml_version = _nvml_version,
         nvtx_version = _nvtx_version,
@@ -440,7 +443,6 @@ def _create_local_toolchains_repository(repository_ctx):
     if not enable_cuda(repository_ctx):
         cuda_defines["%{cuda_toolkit_path}"] = ""
         cuda_defines["%{cuda_nvcc_files}"] = "[]"
-        nvcc_relative_path = ""
     else:
         if is_clang_compiler:
             cuda_defines["%{cuda_toolkit_path}"] = repository_ctx.attr.nvcc_binary.workspace_root
@@ -448,10 +450,6 @@ def _create_local_toolchains_repository(repository_ctx):
             cuda_defines["%{cuda_toolkit_path}"] = ""
         cuda_defines["%{cuda_nvcc_files}"] = "if_cuda([\"@{nvcc_archive}//:bin\", \"@{nvcc_archive}//:nvvm\"])".format(
             nvcc_archive = repository_ctx.attr.nvcc_binary.repo_name,
-        )
-        nvcc_relative_path = "%s/%s" % (
-            repository_ctx.attr.nvcc_binary.workspace_root,
-            repository_ctx.attr.nvcc_binary.name,
         )
     if is_clang_compiler:
         cuda_defines["%{compiler}"] = "clang"
@@ -718,28 +716,8 @@ _CUDA_NVCC = "CUDA_NVCC"
 _TF_SYSROOT = "TF_SYSROOT"
 _TMPDIR = "TMPDIR"
 
-_ENVIRONS = [
-    _CC,
-    _CLANG_CUDA_COMPILER_PATH,
-    TF_NEED_CUDA,
-    _TF_NEED_ROCM,
-    _TF_NVCC_CLANG,
-    _CUDA_NVCC,
-    TF_CUDA_VERSION,
-    HERMETIC_CUDA_VERSION,
-    _TF_CUDA_COMPUTE_CAPABILITIES,
-    _HERMETIC_CUDA_COMPUTE_CAPABILITIES,
-    _TF_SYSROOT,
-    "TMP",
-    _TMPDIR,
-    "LOCAL_CUDA_PATH",
-    "LOCAL_CUDNN_PATH",
-    USE_CUDA_REDISTRIBUTIONS,
-]
-
 cuda_configure = repository_rule(
     implementation = _cuda_configure_impl,
-    environ = _ENVIRONS,
     attrs = {
         "environ": attr.string_dict(),
         "cccl_version": attr.label(default = Label("@cuda_cccl//:version.bzl")),

--- a/third_party/gpus/cuda/hermetic/cuda_cudart.BUILD.tpl
+++ b/third_party/gpus/cuda/hermetic/cuda_cudart.BUILD.tpl
@@ -4,6 +4,10 @@ load(
     "cuda_rpath_flags",
 )
 
+exports_files([
+    "include/cuda.h",
+])
+
 filegroup(
     name = "static",
     srcs = ["lib/libcudart_static.a"],

--- a/third_party/gpus/cuda/hermetic/cuda_json_init_repository.bzl
+++ b/third_party/gpus/cuda/hermetic/cuda_json_init_repository.bzl
@@ -14,7 +14,10 @@
 
 """Hermetic CUDA redistributions JSON repository initialization. Consult the WORKSPACE on how to use it."""
 
-load("//third_party:repo.bzl", "tf_mirror_urls")
+load(
+    "//third_party/gpus:nvidia_common_rules.bzl",
+    "json_init_repository",
+)
 load(
     "//third_party/gpus/cuda/hermetic:cuda_redist_versions.bzl",
     "CUDA_REDIST_JSON_DICT",
@@ -23,147 +26,30 @@ load(
     "MIRRORED_TARS_CUDNN_REDIST_JSON_DICT",
 )
 
-def _get_env_var(ctx, name):
-    return ctx.os.environ.get(name)
-
-def _get_json_file_content(
-        repository_ctx,
-        url_to_sha256,
-        mirrored_tars_url_to_sha256,
-        json_file_name,
-        mirrored_tars_json_file_name):
-    use_cuda_tars = _get_env_var(
-        repository_ctx,
-        "USE_CUDA_TAR_ARCHIVE_FILES",
-    )
-    (url, sha256) = url_to_sha256
-    if mirrored_tars_url_to_sha256:
-        (mirrored_tar_url, mirrored_tar_sha256) = mirrored_tars_url_to_sha256
-    else:
-        mirrored_tar_url = None
-        mirrored_tar_sha256 = None
-    json_file = None
-
-    if use_cuda_tars and mirrored_tar_url:
-        json_tar_downloaded = repository_ctx.download(
-            url = mirrored_tar_url,
-            sha256 = mirrored_tar_sha256,
-            output = mirrored_tars_json_file_name,
-            allow_fail = True,
-        )
-        if json_tar_downloaded.success:
-            print("Successfully downloaded mirrored tar file: {}".format(
-                mirrored_tar_url,
-            ))  # buildifier: disable=print
-            json_file = mirrored_tars_json_file_name
-        else:
-            print("Failed to download mirrored tar file: {}".format(
-                mirrored_tar_url,
-            ))  # buildifier: disable=print
-
-    if not json_file:
-        repository_ctx.download(
-            url = tf_mirror_urls(url),
-            sha256 = sha256,
-            output = json_file_name,
-        )
-        json_file = json_file_name
-
-    json_content = repository_ctx.read(repository_ctx.path(json_file))
-    repository_ctx.delete(json_file)
-    return json_content
-
-def _cuda_redist_json_impl(repository_ctx):
-    cuda_version = (_get_env_var(repository_ctx, "HERMETIC_CUDA_VERSION") or
-                    _get_env_var(repository_ctx, "TF_CUDA_VERSION"))
-    local_cuda_path = _get_env_var(repository_ctx, "LOCAL_CUDA_PATH")
-    cudnn_version = (_get_env_var(repository_ctx, "HERMETIC_CUDNN_VERSION") or
-                     _get_env_var(repository_ctx, "TF_CUDNN_VERSION"))
-    local_cudnn_path = _get_env_var(repository_ctx, "LOCAL_CUDNN_PATH")
-    supported_cuda_versions = repository_ctx.attr.cuda_json_dict.keys()
-    if (cuda_version and not local_cuda_path and
-        (cuda_version not in supported_cuda_versions)):
-        fail(
-            ("The supported CUDA versions are {supported_versions}." +
-             " Please provide a supported version in HERMETIC_CUDA_VERSION" +
-             " environment variable or add JSON URL for" +
-             " CUDA version={version}.")
-                .format(
-                supported_versions = supported_cuda_versions,
-                version = cuda_version,
-            ),
-        )
-    supported_cudnn_versions = repository_ctx.attr.cudnn_json_dict.keys()
-    if cudnn_version and not local_cudnn_path and (cudnn_version not in supported_cudnn_versions):
-        fail(
-            ("The supported CUDNN versions are {supported_versions}." +
-             " Please provide a supported version in HERMETIC_CUDNN_VERSION" +
-             " environment variable or add JSON URL for" +
-             " CUDNN version={version}.")
-                .format(
-                supported_versions = supported_cudnn_versions,
-                version = cudnn_version,
-            ),
-        )
-    cuda_redistributions = "{}"
-    cudnn_redistributions = "{}"
-    if cuda_version and not local_cuda_path:
-        if cuda_version in repository_ctx.attr.mirrored_tars_cuda_json_dict.keys():
-            mirrored_tars_url_to_sha256 = repository_ctx.attr.mirrored_tars_cuda_json_dict[cuda_version]
-        else:
-            mirrored_tars_url_to_sha256 = {}
-        cuda_redistributions = _get_json_file_content(
-            repository_ctx,
-            url_to_sha256 = repository_ctx.attr.cuda_json_dict[cuda_version],
-            mirrored_tars_url_to_sha256 = mirrored_tars_url_to_sha256,
-            json_file_name = "redistrib_cuda_%s.json" % cuda_version,
-            mirrored_tars_json_file_name = "redistrib_cuda_%s_tar.json" % cuda_version,
-        )
-    if cudnn_version and not local_cudnn_path:
-        if cudnn_version in repository_ctx.attr.mirrored_tars_cudnn_json_dict.keys():
-            mirrored_tars_url_to_sha256 = repository_ctx.attr.mirrored_tars_cudnn_json_dict[cudnn_version]
-        else:
-            mirrored_tars_url_to_sha256 = {}
-        cudnn_redistributions = _get_json_file_content(
-            repository_ctx,
-            mirrored_tars_url_to_sha256 = mirrored_tars_url_to_sha256,
-            url_to_sha256 = repository_ctx.attr.cudnn_json_dict[cudnn_version],
-            json_file_name = "redistrib_cudnn_%s.json" % cudnn_version,
-            mirrored_tars_json_file_name = "redistrib_cudnn_%s_tar.json" % cudnn_version,
-        )
-
+def _combined_redist_json_impl(repository_ctx):
     repository_ctx.file(
         "distributions.bzl",
-        """CUDA_REDISTRIBUTIONS = {cuda_redistributions}
+        """load(
+    "@standalone_cuda_redist_json//:distributions.bzl",
+    _cuda_redistributions = "CUDA_REDISTRIBUTIONS",
+)
+load(
+    "@cudnn_redist_json//:distributions.bzl",
+    _cudnn_redistributions = "CUDNN_REDISTRIBUTIONS",
+)
 
-CUDNN_REDISTRIBUTIONS = {cudnn_redistributions}
-""".format(
-            cuda_redistributions = cuda_redistributions,
-            cudnn_redistributions = cudnn_redistributions,
-        ),
+CUDA_REDISTRIBUTIONS = _cuda_redistributions
+
+CUDNN_REDISTRIBUTIONS = _cudnn_redistributions
+""",
     )
     repository_ctx.file(
         "BUILD",
         "",
     )
 
-cuda_redist_json = repository_rule(
-    implementation = _cuda_redist_json_impl,
-    attrs = {
-        "cuda_json_dict": attr.string_list_dict(mandatory = True),
-        "cudnn_json_dict": attr.string_list_dict(mandatory = True),
-        "mirrored_tars_cuda_json_dict": attr.string_list_dict(mandatory = True),
-        "mirrored_tars_cudnn_json_dict": attr.string_list_dict(mandatory = True),
-    },
-    environ = [
-        "HERMETIC_CUDA_VERSION",
-        "HERMETIC_CUDNN_VERSION",
-        "TF_CUDA_VERSION",
-        "TF_CUDNN_VERSION",
-        "LOCAL_CUDA_PATH",
-        "LOCAL_CUDNN_PATH",
-        "USE_CUDA_TAR_ARCHIVE_FILES",
-    ],
+_combined_redist_json = repository_rule(
+    implementation = _combined_redist_json_impl,
 )
 
 def cuda_json_init_repository(
@@ -171,10 +57,27 @@ def cuda_json_init_repository(
         cudnn_json_dict = CUDNN_REDIST_JSON_DICT,
         mirrored_tars_cuda_json_dict = MIRRORED_TARS_CUDA_REDIST_JSON_DICT,
         mirrored_tars_cudnn_json_dict = MIRRORED_TARS_CUDNN_REDIST_JSON_DICT):
-    cuda_redist_json(
+    json_init_repository(
+        name = "standalone_cuda_redist_json",
+        toolkit_name = "CUDA",
+        json_dict = cuda_json_dict,
+        mirrored_tars_json_dict = mirrored_tars_cuda_json_dict,
+        redist_version_env_vars = ["HERMETIC_CUDA_VERSION", "TF_CUDA_VERSION"],
+        local_path_env_var = "LOCAL_CUDA_PATH",
+        use_tar_file_env_var = "USE_CUDA_TAR_ARCHIVE_FILES",
+    )
+
+    json_init_repository(
+        name = "cudnn_redist_json",
+        toolkit_name = "CUDNN",
+        json_dict = cudnn_json_dict,
+        mirrored_tars_json_dict = mirrored_tars_cudnn_json_dict,
+        redist_version_env_vars = ["HERMETIC_CUDNN_VERSION", "TF_CUDNN_VERSION"],
+        local_path_env_var = "LOCAL_CUDNN_PATH",
+        use_tar_file_env_var = "USE_CUDA_TAR_ARCHIVE_FILES",
+    )
+
+    # This repository is needed to combine the CUDA and CUDNN redistributions.
+    _combined_redist_json(
         name = "cuda_redist_json",
-        cuda_json_dict = cuda_json_dict,
-        cudnn_json_dict = cudnn_json_dict,
-        mirrored_tars_cuda_json_dict = mirrored_tars_cuda_json_dict,
-        mirrored_tars_cudnn_json_dict = mirrored_tars_cudnn_json_dict,
     )

--- a/third_party/gpus/cuda/hermetic/cuda_nvcc.BUILD.tpl
+++ b/third_party/gpus/cuda/hermetic/cuda_nvcc.BUILD.tpl
@@ -18,6 +18,14 @@ filegroup(
 )
 
 filegroup(
+    name = "nvdisasm",
+    srcs = [
+        "bin/nvdisasm",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
     name = "nvlink",
     srcs = [
         "bin/nvlink",

--- a/third_party/gpus/cuda/hermetic/cuda_nvcc.BUILD.tpl
+++ b/third_party/gpus/cuda/hermetic/cuda_nvcc.BUILD.tpl
@@ -78,7 +78,7 @@ cuda_nvcc_feature(
     name = "feature",
     enabled = True,
     bin = ":bin/nvcc",
-    version = "12.6.3",
+    version = "%{version_of_cuda}",
     visibility = ["@rules_ml_toolchain//cc_toolchain:__pkg__"],
 )
 

--- a/third_party/gpus/cuda/hermetic/cuda_nvcc.BUILD.tpl
+++ b/third_party/gpus/cuda/hermetic/cuda_nvcc.BUILD.tpl
@@ -78,7 +78,7 @@ cuda_nvcc_feature(
     name = "feature",
     enabled = True,
     bin = ":bin/nvcc",
-    version = "%{version_of_cuda}",
+    version = "12.6.3",
     visibility = ["@rules_ml_toolchain//cc_toolchain:__pkg__"],
 )
 

--- a/third_party/gpus/cuda/hermetic/cuda_nvdisasm.BUILD
+++ b/third_party/gpus/cuda/hermetic/cuda_nvdisasm.BUILD
@@ -1,0 +1,13 @@
+licenses(["restricted"])  # NVIDIA proprietary license
+
+exports_files([
+    "bin/nvdisasm",
+])
+
+filegroup(
+    name = "nvdisasm",
+    srcs = [
+        "bin/nvdisasm",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/third_party/gpus/cuda/hermetic/cuda_nvprune.BUILD
+++ b/third_party/gpus/cuda/hermetic/cuda_nvprune.BUILD
@@ -1,0 +1,9 @@
+licenses(["restricted"])  # NVIDIA proprietary license
+
+filegroup(
+    name = "nvprune",
+    srcs = [
+        "bin/nvprune",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/third_party/gpus/cuda/hermetic/cuda_redist_init_repositories.bzl
+++ b/third_party/gpus/cuda/hermetic/cuda_redist_init_repositories.bzl
@@ -14,7 +14,12 @@
 
 """Hermetic CUDA repositories initialization. Consult the WORKSPACE on how to use it."""
 
-load("//third_party:repo.bzl", "tf_mirror_urls")
+load(
+    "//third_party/gpus:nvidia_common_rules.bzl",
+    "get_redistribution_urls",
+    "get_version_and_template_lists",
+    "redist_init_repository",
+)
 load(
     "//third_party/gpus/cuda/hermetic:cuda_redist_versions.bzl",
     "CUDA_REDIST_PATH_PREFIX",
@@ -24,583 +29,38 @@ load(
     "REDIST_VERSIONS_TO_BUILD_TEMPLATES",
 )
 
-OS_ARCH_DICT = {
-    "amd64": "x86_64-unknown-linux-gnu",
-    "aarch64": "aarch64-unknown-linux-gnu",
-    "tegra-aarch64": "tegra-aarch64-unknown-linux-gnu",
-}
-_REDIST_ARCH_DICT = {
-    "linux-x86_64": "x86_64-unknown-linux-gnu",
-    "linux-sbsa": "aarch64-unknown-linux-gnu",
-    "linux-aarch64": "tegra-aarch64-unknown-linux-gnu",
-}
-
-TEGRA = "tegra"
-
-SUPPORTED_ARCHIVE_EXTENSIONS = [
-    ".zip",
-    ".jar",
-    ".war",
-    ".aar",
-    ".tar",
-    ".tar.gz",
-    ".tgz",
-    ".tar.xz",
-    ".txz",
-    ".tar.zst",
-    ".tzst",
-    ".tar.bz2",
-    ".tbz",
-    ".ar",
-    ".deb",
-    ".whl",
-]
-
-def get_env_var(ctx, name):
-    return ctx.os.environ.get(name)
-
-def _get_file_name(url):
-    last_slash_index = url.rfind("/")
-    return url[last_slash_index + 1:]
-
-def get_archive_name(url):
-    # buildifier: disable=function-docstring-return
-    # buildifier: disable=function-docstring-args
-    """Returns the archive name without extension."""
-    filename = _get_file_name(url)
-    for extension in SUPPORTED_ARCHIVE_EXTENSIONS:
-        if filename.endswith(extension):
-            return filename[:-len(extension)]
-    return filename
-
-LIB_EXTENSION = ".so."
-
-def _get_lib_name_and_version(path):
-    extension_index = path.rfind(LIB_EXTENSION)
-    last_slash_index = path.rfind("/")
-    lib_name = path[last_slash_index + 1:extension_index]
-    lib_version = path[extension_index + len(LIB_EXTENSION):]
-    return (lib_name, lib_version)
-
-def _get_main_lib_name(repository_ctx):
-    if repository_ctx.name == "cuda_driver":
-        return "libcuda"
-    else:
-        return "lib{}".format(
-            repository_ctx.name.split("_")[1],
-        ).lower()
-
-def _get_libraries_by_redist_name_in_dir(repository_ctx):
-    lib_dir_path = repository_ctx.path("lib")
-    if not lib_dir_path.exists:
-        return []
-    main_lib_name = _get_main_lib_name(repository_ctx)
-    lib_dir_content = lib_dir_path.readdir()
-    return [
-        str(f)
-        for f in lib_dir_content
-        if (LIB_EXTENSION in str(f) and
-            main_lib_name in str(f).lower())
-    ]
-
-def get_lib_name_to_version_dict(repository_ctx):
-    # buildifier: disable=function-docstring-return
-    # buildifier: disable=function-docstring-args
-    """Returns a dict of library names and major versions."""
-    lib_name_to_version_dict = {}
-    for path in _get_libraries_by_redist_name_in_dir(repository_ctx):
-        lib_name, lib_version = _get_lib_name_and_version(path)
-        major_version_key = "%%{%s_version}" % lib_name.lower()
-        minor_version_key = "%%{%s_minor_version}" % lib_name.lower()
-
-        # We need to find either major or major.minor version if there is no
-        # file with major version. E.g. if we have the following files:
-        # libcudart.so
-        # libcudart.so.12
-        # libcudart.so.12.3.2,
-        # we will save save {"%{libcudart_version}": "12",
-        # "%{libcudart_minor_version}": "12.3.2"}
-        if len(lib_version.split(".")) == 1:
-            lib_name_to_version_dict[major_version_key] = lib_version
-        if len(lib_version.split(".")) == 2:
-            lib_name_to_version_dict[minor_version_key] = lib_version
-            if (major_version_key not in lib_name_to_version_dict or
-                len(lib_name_to_version_dict[major_version_key].split(".")) > 2):
-                lib_name_to_version_dict[major_version_key] = lib_version
-        if len(lib_version.split(".")) >= 3:
-            if major_version_key not in lib_name_to_version_dict:
-                lib_name_to_version_dict[major_version_key] = lib_version
-            if minor_version_key not in lib_name_to_version_dict:
-                lib_name_to_version_dict[minor_version_key] = lib_version
-    return lib_name_to_version_dict
-
-def create_dummy_build_file(repository_ctx, use_comment_symbols = True):
-    repository_ctx.template(
-        "BUILD",
-        repository_ctx.attr.build_templates[0],
-        {
-            "%{multiline_comment}": "'''" if use_comment_symbols else "",
-            "%{comment}": "#" if use_comment_symbols else "",
-        },
-    )
-
-def create_cuda_nvcc_build_file(repository_ctx, use_comment_symbols = True):
-    cuda_version = (get_env_var(repository_ctx, "HERMETIC_CUDA_VERSION") or
-                    get_env_var(repository_ctx, "TF_CUDA_VERSION"))
-    repository_ctx.template(
-        "BUILD",
-        repository_ctx.attr.build_templates[0],
-        {
-            "%{multiline_comment}": "'''" if use_comment_symbols else "",
-            "%{comment}": "#" if use_comment_symbols else "",
-            "%{version_of_cuda}": cuda_version,
-        },
-    )
-
-def _get_build_template(repository_ctx, major_lib_version):
-    template = None
-    for i in range(0, len(repository_ctx.attr.versions)):
-        for dist_version in repository_ctx.attr.versions[i].split(","):
-            if dist_version == major_lib_version:
-                template = repository_ctx.attr.build_templates[i]
-                break
-    if not template:
-        fail("No build template found for {} version {}".format(
-            repository_ctx.name,
-            major_lib_version,
-        ))
-    return template
-
-def get_major_library_version(repository_ctx, lib_name_to_version_dict):
-    # buildifier: disable=function-docstring-return
-    # buildifier: disable=function-docstring-args
-    """Returns the major library version provided the versions dict."""
-    main_lib_name = _get_main_lib_name(repository_ctx)
-    key = "%%{%s_version}" % main_lib_name
-    if key not in lib_name_to_version_dict:
-        return ""
-    return lib_name_to_version_dict[key]
-
-def create_build_file(
-        repository_ctx,
-        lib_name_to_version_dict,
-        major_lib_version):
-    # buildifier: disable=function-docstring-args
-    """Creates a BUILD file for the repository."""
-    if len(major_lib_version) == 0:
-        build_template_content = repository_ctx.read(
-            repository_ctx.attr.build_templates[0],
-        )
-
-        if repository_ctx.name == "cuda_nvcc":
-            create_cuda_nvcc_build_file(
-                repository_ctx,
-                use_comment_symbols = True if "_version}" in build_template_content else False,
-            )
-        else:
-            create_dummy_build_file(
-                repository_ctx,
-                use_comment_symbols = True if "_version}" in build_template_content else False,
-            )
-        return
-    build_template = _get_build_template(
-        repository_ctx,
-        major_lib_version.split(".")[0],
-    )
-    repository_ctx.template(
-        "BUILD",
-        build_template,
-        lib_name_to_version_dict | {
-            "%{multiline_comment}": "",
-            "%{comment}": "",
-        },
-    )
-
-def _create_symlinks(repository_ctx, local_path, dirs):
-    for dir in dirs:
-        dir_path = "{path}/{dir}".format(
-            path = local_path,
-            dir = dir,
-        )
-        if not repository_ctx.path(local_path).exists:
-            fail("%s directory doesn't exist!" % dir_path)
-        repository_ctx.symlink(dir_path, dir)
-
-def _create_libcuda_symlinks(
-        repository_ctx,
-        lib_name_to_version_dict):
-    if repository_ctx.name == "cuda_driver":
-        key = "%{libcuda_version}"
-        if key not in lib_name_to_version_dict:
-            return
-        nvidia_driver_path = "lib/libcuda.so.{}".format(
-            lib_name_to_version_dict[key],
-        )
-        if not repository_ctx.path(nvidia_driver_path).exists:
-            fail("%s doesn't exist!" % nvidia_driver_path)
-        repository_ctx.symlink(nvidia_driver_path, "lib/libcuda.so.1")
-        repository_ctx.symlink("lib/libcuda.so.1", "lib/libcuda.so")
-
-def _create_cuda_header_symlinks(repository_ctx):
-    if repository_ctx.name == "cuda_nvcc":
-        repository_ctx.symlink("../cuda_cudart/include/cuda.h", "include/cuda.h")
-
-def _create_cuda_version_file(repository_ctx, lib_name_to_version_dict):
-    key = "%{libcudart_version}"
-    major_cudart_version = lib_name_to_version_dict[key] if key in lib_name_to_version_dict else ""
-    if repository_ctx.name == "cuda_cudart":
-        repository_ctx.file(
-            "cuda_version.bzl",
-            "MAJOR_CUDA_VERSION = \"{}\"".format(major_cudart_version),
-        )
-
-def create_version_file(repository_ctx, major_lib_version):
-    repository_ctx.file(
-        "version.bzl",
-        "VERSION = \"{}\"".format(major_lib_version),
-    )
-
-def use_local_path(repository_ctx, local_path, dirs):
-    # buildifier: disable=function-docstring-args
-    """Creates repository using local redistribution paths."""
-    _create_symlinks(
-        repository_ctx,
-        local_path,
-        dirs,
-    )
-    lib_name_to_version_dict = get_lib_name_to_version_dict(repository_ctx)
-    major_version = get_major_library_version(
-        repository_ctx,
-        lib_name_to_version_dict,
-    )
-    create_build_file(
-        repository_ctx,
-        lib_name_to_version_dict,
-        major_version,
-    )
-    _create_libcuda_symlinks(
-        repository_ctx,
-        lib_name_to_version_dict,
-    )
-    _create_cuda_version_file(repository_ctx, lib_name_to_version_dict)
-    create_version_file(repository_ctx, major_version)
-
-def _use_local_cuda_path(repository_ctx, local_cuda_path):
-    # buildifier: disable=function-docstring-args
-    """ Creates symlinks and initializes hermetic CUDA repository."""
-    use_local_path(
-        repository_ctx,
-        local_cuda_path,
-        ["include", "lib", "bin", "nvvm"],
-    )
-
-def _use_local_cudnn_path(repository_ctx, local_cudnn_path):
-    # buildifier: disable=function-docstring-args
-    """ Creates symlinks and initializes hermetic CUDNN repository."""
-    use_local_path(repository_ctx, local_cudnn_path, ["include", "lib"])
-
-def _download_redistribution(
-        repository_ctx,
-        arch_key,
-        path_prefix,
-        mirrored_tar_path_prefix):
-    (url, sha256) = repository_ctx.attr.url_dict[arch_key]
-    use_cuda_tars = get_env_var(
-        repository_ctx,
-        "USE_CUDA_TAR_ARCHIVE_FILES",
-    )
-
-    # If url is not relative, then appending prefix is not needed.
-    if not (url.startswith("http") or url.startswith("file:///")):
-        if use_cuda_tars:
-            url = mirrored_tar_path_prefix + url
-        else:
-            url = path_prefix + url
-    archive_name = get_archive_name(url)
-    file_name = _get_file_name(url)
-    urls = [url] if use_cuda_tars else tf_mirror_urls(url)
-
-    print("Downloading and extracting {}".format(url))  # buildifier: disable=print
-    repository_ctx.download(
-        url = urls,
-        output = file_name,
-        sha256 = sha256,
-    )
-    if repository_ctx.attr.override_strip_prefix:
-        strip_prefix = repository_ctx.attr.override_strip_prefix
-    else:
-        strip_prefix = archive_name
-    repository_ctx.extract(
-        archive = file_name,
-        stripPrefix = strip_prefix,
-    )
-    repository_ctx.delete(file_name)
-
-def _get_platform_architecture(repository_ctx):
-    target_arch = get_env_var(repository_ctx, "CUDA_REDIST_TARGET_PLATFORM")
-
-    # We use NVCC compiler as the host compiler.
-    if target_arch and repository_ctx.name != "cuda_nvcc":
-        if target_arch in OS_ARCH_DICT.keys():
-            host_arch = target_arch
-        else:
-            fail(
-                "Unsupported architecture: {arch}, use one of {supported}".format(
-                    arch = target_arch,
-                    supported = OS_ARCH_DICT.keys(),
-                ),
-            )
-    else:
-        host_arch = repository_ctx.os.arch
-
-    if host_arch == "aarch64":
-        uname_result = repository_ctx.execute(["uname", "-a"]).stdout
-        if TEGRA in uname_result:
-            return "{}-{}".format(TEGRA, host_arch)
-    return host_arch
-
-def _use_downloaded_cuda_redistribution(repository_ctx):
-    # buildifier: disable=function-docstring-args
-    """ Downloads CUDA redistribution and initializes hermetic CUDA repository."""
-    major_version = ""
-    cuda_version = (get_env_var(repository_ctx, "HERMETIC_CUDA_VERSION") or
-                    get_env_var(repository_ctx, "TF_CUDA_VERSION"))
-    if not cuda_version:
-        # If no CUDA version is found, comment out all cc_import targets.
-        create_dummy_build_file(repository_ctx)
-        _create_cuda_version_file(repository_ctx, {})
-        create_version_file(repository_ctx, major_version)
-        return
-
-    if len(repository_ctx.attr.url_dict) == 0:
-        print("{} is not found in redistributions list.".format(
-            repository_ctx.name,
-        ))  # buildifier: disable=print
-        create_dummy_build_file(repository_ctx)
-        _create_cuda_version_file(repository_ctx, {})
-        create_version_file(repository_ctx, major_version)
-        return
-
-    # Download archive only when GPU config is used.
-    arch_key = OS_ARCH_DICT[_get_platform_architecture(repository_ctx)]
-    if arch_key not in repository_ctx.attr.url_dict.keys():
-        fail(
-            ("The supported platforms are {supported_platforms}." +
-             " Platform {platform} is not supported for {dist_name}.")
-                .format(
-                supported_platforms = repository_ctx.attr.url_dict.keys(),
-                platform = arch_key,
-                dist_name = repository_ctx.name,
-            ),
-        )
-    _download_redistribution(
-        repository_ctx,
-        arch_key,
-        repository_ctx.attr.cuda_redist_path_prefix,
-        repository_ctx.attr.mirrored_tar_cuda_redist_path_prefix,
-    )
-    lib_name_to_version_dict = get_lib_name_to_version_dict(repository_ctx)
-    major_version = get_major_library_version(repository_ctx, lib_name_to_version_dict)
-    create_build_file(
-        repository_ctx,
-        lib_name_to_version_dict,
-        major_version,
-    )
-    _create_libcuda_symlinks(
-        repository_ctx,
-        lib_name_to_version_dict,
-    )
-    _create_cuda_header_symlinks(repository_ctx)
-    _create_cuda_version_file(repository_ctx, lib_name_to_version_dict)
-    create_version_file(repository_ctx, major_version)
-
-def _cuda_repo_impl(repository_ctx):
-    local_cuda_path = get_env_var(repository_ctx, "LOCAL_CUDA_PATH")
-    if local_cuda_path:
-        _use_local_cuda_path(repository_ctx, local_cuda_path)
-    else:
-        _use_downloaded_cuda_redistribution(repository_ctx)
-
-cuda_repo = repository_rule(
-    implementation = _cuda_repo_impl,
-    attrs = {
-        "url_dict": attr.string_list_dict(mandatory = True),
-        "versions": attr.string_list(mandatory = True),
-        "build_templates": attr.label_list(mandatory = True),
-        "override_strip_prefix": attr.string(),
-        "cuda_redist_path_prefix": attr.string(),
-        "mirrored_tar_cuda_redist_path_prefix": attr.string(mandatory = False),
-    },
-    environ = [
-        "HERMETIC_CUDA_VERSION",
-        "TF_CUDA_VERSION",
-        "LOCAL_CUDA_PATH",
-        "CUDA_REDIST_TARGET_PLATFORM",
-        "USE_CUDA_TAR_ARCHIVE_FILES",
-    ],
-)
-
-def _use_downloaded_cudnn_redistribution(repository_ctx):
-    # buildifier: disable=function-docstring-args
-    """ Downloads CUDNN redistribution and initializes hermetic CUDNN repository."""
-    cudnn_version = None
-    major_version = ""
-    cudnn_version = (get_env_var(repository_ctx, "HERMETIC_CUDNN_VERSION") or
-                     get_env_var(repository_ctx, "TF_CUDNN_VERSION"))
-    cuda_version = (get_env_var(repository_ctx, "HERMETIC_CUDA_VERSION") or
-                    get_env_var(repository_ctx, "TF_CUDA_VERSION"))
-    if not cudnn_version:
-        # If no CUDNN version is found, comment out cc_import targets.
-        create_dummy_build_file(repository_ctx)
-        create_version_file(repository_ctx, major_version)
-        return
-
-    if len(repository_ctx.attr.url_dict) == 0:
-        print("{} is not found in redistributions list.".format(
-            repository_ctx.name,
-        ))  # buildifier: disable=print
-        create_dummy_build_file(repository_ctx)
-        create_version_file(repository_ctx, major_version)
-        return
-
-    # Download archive only when GPU config is used.
-    arch_key = OS_ARCH_DICT[_get_platform_architecture(repository_ctx)]
-    if arch_key not in repository_ctx.attr.url_dict.keys():
-        arch_key = "cuda{version}_{arch}".format(
-            version = cuda_version.split(".")[0],
-            arch = arch_key,
-        )
-    if arch_key not in repository_ctx.attr.url_dict.keys():
-        fail(
-            ("The supported platforms are {supported_platforms}." +
-             " Platform {platform} is not supported for {dist_name}.")
-                .format(
-                supported_platforms = repository_ctx.attr.url_dict.keys(),
-                platform = arch_key,
-                dist_name = repository_ctx.name,
-            ),
-        )
-
-    _download_redistribution(
-        repository_ctx,
-        arch_key,
-        repository_ctx.attr.cudnn_redist_path_prefix,
-        repository_ctx.attr.mirrored_tar_cudnn_redist_path_prefix,
-    )
-
-    lib_name_to_version_dict = get_lib_name_to_version_dict(repository_ctx)
-    major_version = get_major_library_version(
-        repository_ctx,
-        lib_name_to_version_dict,
-    )
-    create_build_file(
-        repository_ctx,
-        lib_name_to_version_dict,
-        major_version,
-    )
-
-    create_version_file(repository_ctx, major_version)
-
-def _cudnn_repo_impl(repository_ctx):
-    local_cudnn_path = get_env_var(repository_ctx, "LOCAL_CUDNN_PATH")
-    if local_cudnn_path:
-        _use_local_cudnn_path(repository_ctx, local_cudnn_path)
-    else:
-        _use_downloaded_cudnn_redistribution(repository_ctx)
-
-cudnn_repo = repository_rule(
-    implementation = _cudnn_repo_impl,
-    attrs = {
-        "url_dict": attr.string_list_dict(mandatory = True),
-        "versions": attr.string_list(mandatory = True),
-        "build_templates": attr.label_list(mandatory = True),
-        "override_strip_prefix": attr.string(),
-        "cudnn_redist_path_prefix": attr.string(),
-        "mirrored_tar_cudnn_redist_path_prefix": attr.string(),
-    },
-    environ = [
-        "HERMETIC_CUDNN_VERSION",
-        "TF_CUDNN_VERSION",
-        "HERMETIC_CUDA_VERSION",
-        "TF_CUDA_VERSION",
-        "LOCAL_CUDNN_PATH",
-        "CUDA_REDIST_TARGET_PLATFORM",
-        "USE_CUDA_TAR_ARCHIVE_FILES",
-    ],
-)
-
-def _get_redistribution_urls(dist_info):
-    url_dict = {}
-    for arch in _REDIST_ARCH_DICT.keys():
-        arch_key = arch
-        if arch_key == "linux-aarch64" and arch_key not in dist_info:
-            arch_key = "linux-sbsa"
-        if arch_key not in dist_info:
-            continue
-        if "relative_path" in dist_info[arch_key]:
-            url_dict[_REDIST_ARCH_DICT[arch]] = [
-                dist_info[arch_key]["relative_path"],
-                dist_info[arch_key].get("sha256", ""),
-            ]
-            continue
-
-        if "full_path" in dist_info[arch_key]:
-            url_dict[_REDIST_ARCH_DICT[arch]] = [
-                dist_info[arch_key]["full_path"],
-                dist_info[arch_key].get("sha256", ""),
-            ]
-            continue
-
-        for cuda_version, data in dist_info[arch_key].items():
-            # CUDNN JSON might contain paths for each CUDA version.
-            path_key = "relative_path"
-            if path_key not in data.keys():
-                path_key = "full_path"
-            url_dict["{cuda_version}_{arch}".format(
-                cuda_version = cuda_version,
-                arch = _REDIST_ARCH_DICT[arch],
-            )] = [data[path_key], data.get("sha256", "")]
-    return url_dict
-
-def get_version_and_template_lists(version_to_template):
-    # buildifier: disable=function-docstring-return
-    # buildifier: disable=function-docstring-args
-    """Returns lists of versions and templates provided in the dict."""
-    template_to_version_map = {}
-    for version, template in version_to_template.items():
-        if template not in template_to_version_map.keys():
-            template_to_version_map[template] = [version]
-        else:
-            template_to_version_map[template].append(version)
-    version_list = []
-    template_list = []
-    for template, versions in template_to_version_map.items():
-        version_list.append(",".join(versions))
-        template_list.append(Label(template))
-    return (version_list, template_list)
-
 def cudnn_redist_init_repository(
         cudnn_redistributions,
         cudnn_redist_path_prefix = CUDNN_REDIST_PATH_PREFIX,
         mirrored_tar_cudnn_redist_path_prefix = MIRRORED_TAR_CUDNN_REDIST_PATH_PREFIX,
         redist_versions_to_build_templates = REDIST_VERSIONS_TO_BUILD_TEMPLATES):
     # buildifier: disable=function-docstring-args
-    """Initializes CUDNN repository."""
+    """Initializes CUDNN repository.
+
+    Please note that this macro should be called from a different file than
+    cuda_json_init_repository(). The reason is that cuda_json_init_repository()
+    creates distributions.bzl file with "CUDNN_REDISTRIBUTIONS" constant that is
+    used in this macro."""
     if "cudnn" in cudnn_redistributions.keys():
-        url_dict = _get_redistribution_urls(cudnn_redistributions["cudnn"])
+        url_dict = get_redistribution_urls(cudnn_redistributions["cudnn"])
     else:
         url_dict = {}
     repo_data = redist_versions_to_build_templates["cudnn"]
     versions, templates = get_version_and_template_lists(
         repo_data["version_to_template"],
     )
-    cudnn_repo(
+    redist_init_repository(
         name = repo_data["repo_name"],
         versions = versions,
         build_templates = templates,
         url_dict = url_dict,
-        cudnn_redist_path_prefix = cudnn_redist_path_prefix,
-        mirrored_tar_cudnn_redist_path_prefix = mirrored_tar_cudnn_redist_path_prefix,
+        redist_path_prefix = cudnn_redist_path_prefix,
+        mirrored_tar_redist_path_prefix = mirrored_tar_cudnn_redist_path_prefix,
+        redist_version_env_vars = ["HERMETIC_CUDNN_VERSION", "TF_CUDNN_VERSION"],
+        local_path_env_var = "LOCAL_CUDNN_PATH",
+        use_tar_file_env_var = "USE_CUDA_TAR_ARCHIVE_FILES",
+        target_arch_env_var = "CUDA_REDIST_TARGET_PLATFORM",
+        local_source_dirs = ["include", "lib"],
     )
 
 def cuda_redist_init_repositories(
@@ -609,23 +69,37 @@ def cuda_redist_init_repositories(
         mirrored_tar_cuda_redist_path_prefix = MIRRORED_TAR_CUDA_REDIST_PATH_PREFIX,
         redist_versions_to_build_templates = REDIST_VERSIONS_TO_BUILD_TEMPLATES):
     # buildifier: disable=function-docstring-args
-    """Initializes CUDA repositories."""
+    """Initializes CUDA repositories.
+
+    Please note that this macro should be called from a different file than
+    cuda_json_init_repository(). The reason is that cuda_json_init_repository()
+    creates distributions.bzl file with "CUDA_REDISTRIBUTIONS" constant that is
+    used in this macro."""
     for redist_name, _ in redist_versions_to_build_templates.items():
         if redist_name in ["cudnn", "cuda_nccl"]:
             continue
         if redist_name in cuda_redistributions.keys():
-            url_dict = _get_redistribution_urls(cuda_redistributions[redist_name])
+            url_dict = get_redistribution_urls(cuda_redistributions[redist_name])
         else:
             url_dict = {}
         repo_data = redist_versions_to_build_templates[redist_name]
         versions, templates = get_version_and_template_lists(
             repo_data["version_to_template"],
         )
-        cuda_repo(
+        redist_init_repository(
             name = repo_data["repo_name"],
             versions = versions,
             build_templates = templates,
             url_dict = url_dict,
-            cuda_redist_path_prefix = cuda_redist_path_prefix,
-            mirrored_tar_cuda_redist_path_prefix = mirrored_tar_cuda_redist_path_prefix,
+            redist_path_prefix = cuda_redist_path_prefix,
+            mirrored_tar_redist_path_prefix = mirrored_tar_cuda_redist_path_prefix,
+            redist_version_env_vars = ["HERMETIC_CUDA_VERSION", "TF_CUDA_VERSION"],
+            local_path_env_var = "LOCAL_CUDA_PATH",
+            use_tar_file_env_var = "USE_CUDA_TAR_ARCHIVE_FILES",
+            target_arch_env_var = "CUDA_REDIST_TARGET_PLATFORM",
+            local_source_dirs = ["include", "lib", "bin", "nvvm"],
+            repository_symlinks = {
+                Label("@cuda_cudart//:include/cuda.h"): "include/cuda.h",
+                Label("@cuda_nvdisasm//:bin/nvdisasm"): "bin/nvdisasm",
+            } if repo_data["repo_name"] == "cuda_nvcc" else {},
         )

--- a/third_party/gpus/cuda/hermetic/cuda_redist_versions.bzl
+++ b/third_party/gpus/cuda/hermetic/cuda_redist_versions.bzl
@@ -15,9 +15,11 @@
 """Hermetic CUDA redistribution versions."""
 
 CUDA_REDIST_PATH_PREFIX = "https://developer.download.nvidia.com/compute/cuda/redist/"
+NVSHMEM_REDIST_PATH_PREFIX = "https://developer.download.nvidia.com/compute/nvshmem/redist/"
 CUDNN_REDIST_PATH_PREFIX = "https://developer.download.nvidia.com/compute/cudnn/redist/"
 MIRRORED_TAR_CUDA_REDIST_PATH_PREFIX = "https://storage.googleapis.com/mirror.tensorflow.org/developer.download.nvidia.com/compute/cuda/redist/"
 MIRRORED_TAR_CUDNN_REDIST_PATH_PREFIX = "https://storage.googleapis.com/mirror.tensorflow.org/developer.download.nvidia.com/compute/cudnn/redist/"
+MIRRORED_TAR_NVSHMEM_REDIST_PATH_PREFIX = "https://storage.googleapis.com/mirror.tensorflow.org/developer.download.nvidia.com/compute/nvshmem/redist/"
 
 CUDA_REDIST_JSON_DICT = {
     "11.8": [
@@ -263,6 +265,20 @@ MIRRORED_TARS_CUDNN_REDIST_JSON_DICT = {
     ],
 }
 
+NVSHMEM_REDIST_JSON_DICT = {
+    "3.2.5": [
+        "https://developer.download.nvidia.com/compute/nvshmem/redist/redistrib_3.2.5.json",
+        "6945425d3bfd24de23c045996f93ec720c010379bfd6f0860ac5f2716659442d",
+    ],
+}
+
+MIRRORED_TARS_NVSHMEM_REDIST_JSON_DICT = {
+    "3.2.5": [
+        "https://storage.googleapis.com/mirror.tensorflow.org/developer.download.nvidia.com/compute/nvshmem/redist/redistrib_3.2.5_tar.json",
+        "641f7ca7048e4acfb466ce8be722f4828b2fa6b8671c28f6e8c230344484fd1c",
+    ],
+}
+
 CUDA_12_NCCL_WHEEL_DICT = {
     "x86_64-unknown-linux-gnu": {
         "version": "2.25.1",
@@ -325,6 +341,7 @@ PTX_VERSION_DICT = {
         "12.5": "8.5",
         "12.6": "8.5",
         "12.8": "8.7",
+        "12.9": "8.8",
     },
 }
 
@@ -433,6 +450,12 @@ REDIST_VERSIONS_TO_BUILD_TEMPLATES = {
             "11": "//third_party/gpus/cuda/hermetic:cuda_nvcc.BUILD.tpl",
         },
     },
+    "cuda_nvdisasm": {
+        "repo_name": "cuda_nvdisasm",
+        "version_to_template": {
+            "12": "//third_party/gpus/cuda/hermetic:cuda_nvdisasm.BUILD",
+        },
+    },
     "cuda_nvml_dev": {
         "repo_name": "cuda_nvml",
         "version_to_template": {
@@ -444,9 +467,9 @@ REDIST_VERSIONS_TO_BUILD_TEMPLATES = {
     "cuda_nvprune": {
         "repo_name": "cuda_nvprune",
         "version_to_template": {
-            "13": "//third_party/gpus/cuda/hermetic:cuda_nvprune.BUILD.tpl",
-            "12": "//third_party/gpus/cuda/hermetic:cuda_nvprune.BUILD.tpl",
-            "11": "//third_party/gpus/cuda/hermetic:cuda_nvprune.BUILD.tpl",
+            "13": "//third_party/gpus/cuda/hermetic:cuda_nvprune.BUILD",
+            "12": "//third_party/gpus/cuda/hermetic:cuda_nvprune.BUILD",
+            "11": "//third_party/gpus/cuda/hermetic:cuda_nvprune.BUILD",
         },
     },
     "cuda_nvtx": {
@@ -455,6 +478,15 @@ REDIST_VERSIONS_TO_BUILD_TEMPLATES = {
             "13": "//third_party/gpus/cuda/hermetic:cuda_nvtx.BUILD.tpl",
             "12": "//third_party/gpus/cuda/hermetic:cuda_nvtx.BUILD.tpl",
             "11": "//third_party/gpus/cuda/hermetic:cuda_nvtx.BUILD.tpl",
+        },
+    },
+}
+
+NVSHMEM_REDIST_VERSIONS_TO_BUILD_TEMPLATES = {
+    "libnvshmem": {
+        "repo_name": "nvidia_nvshmem",
+        "version_to_template": {
+            "3": "//third_party/nvshmem/hermetic:nvidia_nvshmem.BUILD.tpl",
         },
     },
 }

--- a/third_party/gpus/nvidia_common_rules.bzl
+++ b/third_party/gpus/nvidia_common_rules.bzl
@@ -1,0 +1,636 @@
+# Copyright 2025 The TensorFlow Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Common rules and functions for hermetic NVIDIA repositories."""
+
+load("//third_party:repo.bzl", "tf_mirror_urls")
+
+OS_ARCH_DICT = {
+    "amd64": "x86_64-unknown-linux-gnu",
+    "aarch64": "aarch64-unknown-linux-gnu",
+    "tegra-aarch64": "tegra-aarch64-unknown-linux-gnu",
+}
+_REDIST_ARCH_DICT = {
+    "linux-x86_64": "x86_64-unknown-linux-gnu",
+    "linux-sbsa": "aarch64-unknown-linux-gnu",
+    "linux-aarch64": "tegra-aarch64-unknown-linux-gnu",
+}
+_SUPPORTED_ARCHIVE_EXTENSIONS = [
+    ".zip",
+    ".jar",
+    ".war",
+    ".aar",
+    ".tar",
+    ".tar.gz",
+    ".tgz",
+    ".tar.xz",
+    ".txz",
+    ".tar.zst",
+    ".tzst",
+    ".tar.bz2",
+    ".tbz",
+    ".ar",
+    ".deb",
+    ".whl",
+]
+_TEGRA = "tegra"
+_LIB_EXTENSION = ".so."
+
+def get_env_var(repository_ctx, name):
+    return repository_ctx.getenv(name)
+
+def get_cuda_version(repository_ctx):
+    return (get_env_var(repository_ctx, "HERMETIC_CUDA_VERSION") or
+            get_env_var(repository_ctx, "TF_CUDA_VERSION"))
+
+def _get_file_name(url):
+    last_slash_index = url.rfind("/")
+    return url[last_slash_index + 1:]
+
+def get_archive_name(url):
+    # buildifier: disable=function-docstring-return
+    # buildifier: disable=function-docstring-args
+    """Returns the archive name without extension."""
+    filename = _get_file_name(url)
+    for extension in _SUPPORTED_ARCHIVE_EXTENSIONS:
+        if filename.endswith(extension):
+            return filename[:-len(extension)]
+    return filename
+
+def _get_lib_name_and_version(path):
+    extension_index = path.rfind(_LIB_EXTENSION)
+    last_slash_index = path.rfind("/")
+    lib_name = path[last_slash_index + 1:extension_index]
+    lib_version = path[extension_index + len(_LIB_EXTENSION):]
+    return (lib_name, lib_version)
+
+def _get_main_lib_name(repository_ctx):
+    if repository_ctx.name == "cuda_driver":
+        return "libcuda"
+    if repository_ctx.name == "nvidia_nvshmem":
+        return "libnvshmem_host"
+    else:
+        return "lib{}".format(
+            _get_common_lib_name(repository_ctx),
+        )
+
+def _get_common_lib_name(repository_ctx):
+    return repository_ctx.name.split("_")[1].lower()
+
+def _get_libraries_by_redist_name_in_dir(repository_ctx):
+    lib_dir_path = repository_ctx.path("lib")
+    if not lib_dir_path.exists:
+        return []
+    common_lib_name = _get_common_lib_name(repository_ctx)
+    lib_dir_content = lib_dir_path.readdir()
+    return [
+        str(f)
+        for f in lib_dir_content
+        if (_LIB_EXTENSION in str(f) and
+            common_lib_name in str(f).lower())
+    ]
+
+def get_lib_name_to_version_dict(repository_ctx):
+    # buildifier: disable=function-docstring-return
+    # buildifier: disable=function-docstring-args
+    """Returns a dict of library names and major versions."""
+    lib_name_to_version_dict = {}
+    for path in _get_libraries_by_redist_name_in_dir(repository_ctx):
+        lib_name, lib_version = _get_lib_name_and_version(path)
+        major_version_key = "%%{%s_version}" % lib_name.lower()
+        minor_version_key = "%%{%s_minor_version}" % lib_name.lower()
+
+        # We need to find either major or major.minor version if there is no
+        # file with major version. E.g. if we have the following files:
+        # libcudart.so
+        # libcudart.so.12
+        # libcudart.so.12.3.2,
+        # we will save save {"%{libcudart_version}": "12",
+        # "%{libcudart_minor_version}": "12.3.2"}
+        if len(lib_version.split(".")) == 1:
+            lib_name_to_version_dict[major_version_key] = lib_version
+        if len(lib_version.split(".")) == 2:
+            lib_name_to_version_dict[minor_version_key] = lib_version
+            if (major_version_key not in lib_name_to_version_dict or
+                len(lib_name_to_version_dict[major_version_key].split(".")) > 2):
+                lib_name_to_version_dict[major_version_key] = lib_version
+        if len(lib_version.split(".")) >= 3:
+            if major_version_key not in lib_name_to_version_dict:
+                lib_name_to_version_dict[major_version_key] = lib_version
+            if minor_version_key not in lib_name_to_version_dict:
+                lib_name_to_version_dict[minor_version_key] = lib_version
+    return lib_name_to_version_dict
+
+def create_dummy_build_file(repository_ctx, use_comment_symbols = True):
+    repository_ctx.template(
+        "BUILD",
+        repository_ctx.attr.build_templates[0],
+        {
+            "%{multiline_comment}": "'''" if use_comment_symbols else "",
+            "%{comment}": "#" if use_comment_symbols else "",
+        },
+    )
+
+def _get_build_template(repository_ctx, major_lib_version):
+    template = None
+    for i in range(0, len(repository_ctx.attr.versions)):
+        for dist_version in repository_ctx.attr.versions[i].split(","):
+            if dist_version == major_lib_version:
+                template = repository_ctx.attr.build_templates[i]
+                break
+    if not template:
+        fail("No build template found for {} version {}".format(
+            repository_ctx.name,
+            major_lib_version,
+        ))
+    return template
+
+def get_major_library_version(repository_ctx, lib_name_to_version_dict):
+    # buildifier: disable=function-docstring-return
+    # buildifier: disable=function-docstring-args
+    """Returns the major library version provided the versions dict."""
+    main_lib_name = _get_main_lib_name(repository_ctx)
+    key = "%%{%s_version}" % main_lib_name
+    if key not in lib_name_to_version_dict:
+        return ""
+    return lib_name_to_version_dict[key]
+
+def create_build_file(
+        repository_ctx,
+        lib_name_to_version_dict,
+        major_lib_version):
+    # buildifier: disable=function-docstring-args
+    """Creates a BUILD file for the repository."""
+    if len(major_lib_version) == 0:
+        build_template_content = repository_ctx.read(
+            repository_ctx.attr.build_templates[0],
+        )
+        if "_version}" not in build_template_content:
+            create_dummy_build_file(repository_ctx, use_comment_symbols = False)
+        else:
+            create_dummy_build_file(repository_ctx)
+        return
+    build_template = _get_build_template(
+        repository_ctx,
+        major_lib_version.split(".")[0],
+    )
+    repository_ctx.template(
+        "BUILD",
+        build_template,
+        lib_name_to_version_dict | {
+            "%{multiline_comment}": "",
+            "%{comment}": "",
+        },
+    )
+
+def _create_symlinks(repository_ctx, local_path, dirs):
+    for dir in dirs:
+        dir_path = "{path}/{dir}".format(
+            path = local_path,
+            dir = dir,
+        )
+        if not repository_ctx.path(local_path).exists:
+            fail("%s directory doesn't exist!" % dir_path)
+        repository_ctx.symlink(dir_path, dir)
+
+def _create_libcuda_symlinks(
+        repository_ctx,
+        lib_name_to_version_dict):
+    if repository_ctx.name == "cuda_driver":
+        key = "%{libcuda_version}"
+        if key not in lib_name_to_version_dict:
+            return
+        nvidia_driver_path = "lib/libcuda.so.{}".format(
+            lib_name_to_version_dict[key],
+        )
+        if not repository_ctx.path(nvidia_driver_path).exists:
+            fail("%s doesn't exist!" % nvidia_driver_path)
+        repository_ctx.symlink(nvidia_driver_path, "lib/libcuda.so.1")
+        repository_ctx.symlink("lib/libcuda.so.1", "lib/libcuda.so")
+
+def _create_repository_symlinks(repository_ctx):
+    for target, link_name in repository_ctx.attr.repository_symlinks.items():
+        repository_ctx.symlink(repository_ctx.path(target), link_name)
+
+def create_version_file(repository_ctx, major_lib_version):
+    repository_ctx.file(
+        "version.bzl",
+        "VERSION = \"{}\"".format(major_lib_version),
+    )
+
+def use_local_redist_path(repository_ctx, local_redist_path, dirs):
+    # buildifier: disable=function-docstring-args
+    """Creates repository using local redistribution paths."""
+    _create_symlinks(
+        repository_ctx,
+        local_redist_path,
+        dirs,
+    )
+    lib_name_to_version_dict = get_lib_name_to_version_dict(repository_ctx)
+    major_version = get_major_library_version(
+        repository_ctx,
+        lib_name_to_version_dict,
+    )
+    create_build_file(
+        repository_ctx,
+        lib_name_to_version_dict,
+        major_version,
+    )
+    _create_libcuda_symlinks(
+        repository_ctx,
+        lib_name_to_version_dict,
+    )
+    create_version_file(repository_ctx, major_version)
+
+def _download_redistribution(
+        repository_ctx,
+        arch_key,
+        path_prefix,
+        mirrored_tar_path_prefix):
+    # buildifier: disable=function-docstring-args
+    """Downloads and extracts NVIDIA redistribution."""
+    (url, sha256) = repository_ctx.attr.url_dict[arch_key]
+
+    # If url is not relative, then appending prefix is not needed.
+    if not (url.startswith("http") or url.startswith("file:///")):
+        if url.endswith(".tar"):
+            url = mirrored_tar_path_prefix + url
+        else:
+            url = path_prefix + url
+    archive_name = get_archive_name(url)
+    file_name = _get_file_name(url)
+    urls = [url] if url.endswith(".tar") else tf_mirror_urls(url)
+
+    print("Downloading and extracting {}".format(url))  # buildifier: disable=print
+    repository_ctx.download(
+        url = urls,
+        output = file_name,
+        sha256 = sha256,
+    )
+    if repository_ctx.attr.override_strip_prefix:
+        strip_prefix = repository_ctx.attr.override_strip_prefix
+    else:
+        strip_prefix = archive_name
+    repository_ctx.extract(
+        archive = file_name,
+        stripPrefix = strip_prefix,
+    )
+    repository_ctx.delete(file_name)
+
+def _get_platform_architecture(repository_ctx):
+    # buildifier: disable=function-docstring-return
+    # buildifier: disable=function-docstring-args
+    """Returns the platform architecture for the redistribution."""
+    target_arch = get_env_var(repository_ctx, repository_ctx.attr.target_arch_env_var)
+
+    # We use NVCC compiler as the host compiler.
+    if target_arch and repository_ctx.name != "cuda_nvcc":
+        if target_arch in OS_ARCH_DICT.keys():
+            host_arch = target_arch
+        else:
+            fail(
+                "Unsupported architecture: {arch}, use one of {supported}".format(
+                    arch = target_arch,
+                    supported = OS_ARCH_DICT.keys(),
+                ),
+            )
+    else:
+        host_arch = repository_ctx.os.arch
+
+    if host_arch == "aarch64":
+        uname_result = repository_ctx.execute(["uname", "-a"]).stdout
+        if _TEGRA in uname_result:
+            return "{}-{}".format(_TEGRA, host_arch)
+    return host_arch
+
+def _use_downloaded_redistribution(repository_ctx):
+    # buildifier: disable=function-docstring-args
+    """ Downloads redistribution and initializes hermetic repository."""
+    major_version = ""
+    redist_version = _get_redist_version(
+        repository_ctx,
+        repository_ctx.attr.redist_version_env_vars,
+    )
+    cuda_version = get_cuda_version(repository_ctx)
+
+    if not redist_version:
+        # If no toolkit version is found, comment out cc_import targets.
+        create_dummy_build_file(repository_ctx)
+        create_version_file(repository_ctx, major_version)
+        return
+
+    if len(repository_ctx.attr.url_dict) == 0:
+        print("{} is not found in redistributions list.".format(
+            repository_ctx.name,
+        ))  # buildifier: disable=print
+        create_dummy_build_file(repository_ctx)
+        create_version_file(repository_ctx, major_version)
+        return
+
+    # Download archive only when GPU config is used.
+    arch_key = OS_ARCH_DICT[_get_platform_architecture(repository_ctx)]
+    if arch_key not in repository_ctx.attr.url_dict.keys():
+        arch_key = "cuda{version}_{arch}".format(
+            version = cuda_version.split(".")[0],
+            arch = arch_key,
+        )
+    if arch_key not in repository_ctx.attr.url_dict.keys():
+        fail(
+            ("{dist_name}: The supported platforms are {supported_platforms}." +
+             " Platform {platform} is not supported.")
+                .format(
+                supported_platforms = repository_ctx.attr.url_dict.keys(),
+                platform = arch_key,
+                dist_name = repository_ctx.name,
+            ),
+        )
+
+    _download_redistribution(
+        repository_ctx,
+        arch_key,
+        repository_ctx.attr.redist_path_prefix,
+        repository_ctx.attr.mirrored_tar_redist_path_prefix,
+    )
+
+    lib_name_to_version_dict = get_lib_name_to_version_dict(repository_ctx)
+    major_version = get_major_library_version(
+        repository_ctx,
+        lib_name_to_version_dict,
+    )
+    create_build_file(
+        repository_ctx,
+        lib_name_to_version_dict,
+        major_version,
+    )
+    _create_libcuda_symlinks(
+        repository_ctx,
+        lib_name_to_version_dict,
+    )
+    _create_repository_symlinks(repository_ctx)
+    create_version_file(repository_ctx, major_version)
+
+def _redist_repo_impl(repository_ctx):
+    local_redist_path = get_env_var(repository_ctx, repository_ctx.attr.local_path_env_var)
+    if local_redist_path:
+        use_local_redist_path(repository_ctx, local_redist_path, repository_ctx.attr.local_source_dirs)
+    else:
+        _use_downloaded_redistribution(repository_ctx)
+
+_redist_repo = repository_rule(
+    implementation = _redist_repo_impl,
+    attrs = {
+        "url_dict": attr.string_list_dict(mandatory = True),
+        "versions": attr.string_list(mandatory = True),
+        "build_templates": attr.label_list(mandatory = True),
+        "override_strip_prefix": attr.string(),
+        "redist_path_prefix": attr.string(),
+        "mirrored_tar_redist_path_prefix": attr.string(mandatory = False),
+        "redist_version_env_vars": attr.string_list(mandatory = True),
+        "local_path_env_var": attr.string(mandatory = True),
+        "use_tar_file_env_var": attr.string(mandatory = True),
+        "target_arch_env_var": attr.string(mandatory = True),
+        "local_source_dirs": attr.string_list(mandatory = False),
+        "repository_symlinks": attr.label_keyed_string_dict(mandatory = False),
+    },
+)
+
+def redist_init_repository(
+        name,
+        versions,
+        build_templates,
+        url_dict,
+        redist_path_prefix,
+        mirrored_tar_redist_path_prefix,
+        redist_version_env_vars,
+        local_path_env_var,
+        use_tar_file_env_var,
+        target_arch_env_var,
+        local_source_dirs,
+        override_strip_prefix = "",
+        repository_symlinks = {}):
+    # buildifier: disable=function-docstring-args
+    """Initializes repository for individual NVIDIA redistribution."""
+    _redist_repo(
+        name = name,
+        url_dict = url_dict,
+        versions = versions,
+        build_templates = build_templates,
+        override_strip_prefix = override_strip_prefix,
+        redist_path_prefix = redist_path_prefix,
+        mirrored_tar_redist_path_prefix = mirrored_tar_redist_path_prefix,
+        redist_version_env_vars = redist_version_env_vars,
+        local_path_env_var = local_path_env_var,
+        use_tar_file_env_var = use_tar_file_env_var,
+        target_arch_env_var = target_arch_env_var,
+        local_source_dirs = local_source_dirs,
+        repository_symlinks = repository_symlinks,
+    )
+
+def get_redistribution_urls(dist_info):
+    # buildifier: disable=function-docstring-return
+    # buildifier: disable=function-docstring-args
+    """Returns a dict of redistribution URLs and their SHA256 values."""
+    url_dict = {}
+    for arch in _REDIST_ARCH_DICT.keys():
+        arch_key = arch
+        if arch_key == "linux-aarch64" and arch_key not in dist_info:
+            arch_key = "linux-sbsa"
+        if arch_key not in dist_info:
+            continue
+        if "relative_path" in dist_info[arch_key]:
+            url_dict[_REDIST_ARCH_DICT[arch]] = [
+                dist_info[arch_key]["relative_path"],
+                dist_info[arch_key].get("sha256", ""),
+            ]
+            continue
+
+        if "full_path" in dist_info[arch_key]:
+            url_dict[_REDIST_ARCH_DICT[arch]] = [
+                dist_info[arch_key]["full_path"],
+                dist_info[arch_key].get("sha256", ""),
+            ]
+            continue
+
+        for cuda_version, data in dist_info[arch_key].items():
+            # CUDNN and NVSHMEM JSON might contain paths for each CUDA version.
+            path_key = "relative_path"
+            if path_key not in data.keys():
+                path_key = "full_path"
+            url_dict["{cuda_version}_{arch}".format(
+                cuda_version = cuda_version,
+                arch = _REDIST_ARCH_DICT[arch],
+            )] = [data[path_key], data.get("sha256", "")]
+    return url_dict
+
+def get_version_and_template_lists(version_to_template):
+    # buildifier: disable=function-docstring-return
+    # buildifier: disable=function-docstring-args
+    """Returns lists of versions and templates provided in the dict."""
+    template_to_version_map = {}
+    for version, template in version_to_template.items():
+        if template not in template_to_version_map.keys():
+            template_to_version_map[template] = [version]
+        else:
+            template_to_version_map[template].append(version)
+    version_list = []
+    template_list = []
+    for template, versions in template_to_version_map.items():
+        version_list.append(",".join(versions))
+        template_list.append(Label(template))
+    return (version_list, template_list)
+
+def _get_json_file_content(
+        repository_ctx,
+        url_to_sha256,
+        mirrored_tars_url_to_sha256,
+        json_file_name,
+        mirrored_tars_json_file_name,
+        use_tar_file_env_var):
+    # buildifier: disable=function-docstring-args
+    # buildifier: disable=function-docstring-return
+    """ Returns the JSON file content for the NVIDIA redistributions."""
+    use_tars = get_env_var(
+        repository_ctx,
+        use_tar_file_env_var,
+    )
+    (url, sha256) = url_to_sha256
+    if mirrored_tars_url_to_sha256:
+        (mirrored_tar_url, mirrored_tar_sha256) = mirrored_tars_url_to_sha256
+    else:
+        mirrored_tar_url = None
+        mirrored_tar_sha256 = None
+    json_file = None
+
+    if use_tars and mirrored_tar_url:
+        json_tar_downloaded = repository_ctx.download(
+            url = mirrored_tar_url,
+            sha256 = mirrored_tar_sha256,
+            output = mirrored_tars_json_file_name,
+            allow_fail = True,
+        )
+        if json_tar_downloaded.success:
+            print("Successfully downloaded mirrored tar file: {}".format(
+                mirrored_tar_url,
+            ))  # buildifier: disable=print
+            json_file = mirrored_tars_json_file_name
+        else:
+            print("Failed to download mirrored tar file: {}".format(
+                mirrored_tar_url,
+            ))  # buildifier: disable=print
+
+    if not json_file:
+        repository_ctx.download(
+            url = tf_mirror_urls(url),
+            sha256 = sha256,
+            output = json_file_name,
+        )
+        json_file = json_file_name
+
+    json_content = repository_ctx.read(repository_ctx.path(json_file))
+    repository_ctx.delete(json_file)
+    return json_content
+
+def _get_redist_version(repository_ctx, redist_version_env_vars):
+    redist_version = None
+    for redist_version_env_var in redist_version_env_vars:
+        redist_version = get_env_var(repository_ctx, redist_version_env_var)
+        if redist_version:
+            break
+    return redist_version
+
+def _redist_json_impl(repository_ctx):
+    redist_version = _get_redist_version(
+        repository_ctx,
+        repository_ctx.attr.redist_version_env_vars,
+    )
+    local_redist_path = get_env_var(repository_ctx, repository_ctx.attr.local_path_env_var)
+    supported_redist_versions = repository_ctx.attr.json_dict.keys()
+    if (redist_version and not local_redist_path and
+        (redist_version not in supported_redist_versions)):
+        fail(
+            ("The supported {toolkit_name} versions are {supported_versions}." +
+             " Please provide a supported version in {redist_version_env_vars}" +
+             " environment variable(s) or add JSON URL for" +
+             " {toolkit_name} version={version}.")
+                .format(
+                toolkit_name = repository_ctx.attr.toolkit_name,
+                redist_version_env_vars = repository_ctx.attr.redist_version_env_vars,
+                supported_versions = supported_redist_versions,
+                version = redist_version,
+            ),
+        )
+    redistributions = "{}"
+    if redist_version and not local_redist_path:
+        if redist_version in repository_ctx.attr.mirrored_tars_json_dict.keys():
+            mirrored_tars_url_to_sha256 = repository_ctx.attr.mirrored_tars_json_dict[redist_version]
+        else:
+            mirrored_tars_url_to_sha256 = {}
+        redistributions = _get_json_file_content(
+            repository_ctx,
+            url_to_sha256 = repository_ctx.attr.json_dict[redist_version],
+            mirrored_tars_url_to_sha256 = mirrored_tars_url_to_sha256,
+            json_file_name = "redistrib_{toolkit_name}_{redist_version}.json".format(
+                toolkit_name = repository_ctx.attr.toolkit_name,
+                redist_version = redist_version,
+            ),
+            mirrored_tars_json_file_name = "redistrib_{toolkit_name}_{redist_version}_tar.json".format(
+                toolkit_name = repository_ctx.attr.toolkit_name,
+                redist_version = redist_version,
+            ),
+            use_tar_file_env_var = repository_ctx.attr.use_tar_file_env_var,
+        )
+
+    repository_ctx.file(
+        "distributions.bzl",
+        "{toolkit_name}_REDISTRIBUTIONS = {redistributions}".format(
+            toolkit_name = repository_ctx.attr.toolkit_name,
+            redistributions = redistributions,
+        ),
+    )
+    repository_ctx.file(
+        "BUILD",
+        "",
+    )
+
+_redist_json = repository_rule(
+    implementation = _redist_json_impl,
+    attrs = {
+        "toolkit_name": attr.string(mandatory = True),
+        "json_dict": attr.string_list_dict(mandatory = True),
+        "mirrored_tars_json_dict": attr.string_list_dict(mandatory = True),
+        "redist_version_env_vars": attr.string_list(mandatory = True),
+        "local_path_env_var": attr.string(mandatory = True),
+        "use_tar_file_env_var": attr.string(mandatory = True),
+    },
+)
+
+def json_init_repository(
+        name,
+        toolkit_name,
+        json_dict,
+        mirrored_tars_json_dict,
+        redist_version_env_vars,
+        local_path_env_var,
+        use_tar_file_env_var):
+    # buildifier: disable=function-docstring-args
+    """Initializes NVIDIA redistribution JSON repository."""
+    _redist_json(
+        name = name,
+        toolkit_name = toolkit_name,
+        json_dict = json_dict,
+        mirrored_tars_json_dict = mirrored_tars_json_dict,
+        redist_version_env_vars = redist_version_env_vars,
+        local_path_env_var = local_path_env_var,
+        use_tar_file_env_var = use_tar_file_env_var,
+    )

--- a/third_party/implib_so/BUILD.bazel
+++ b/third_party/implib_so/BUILD.bazel
@@ -1,0 +1,21 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # MIT
+
+py_binary(
+    name = "get_symbols",
+    srcs = ["get_symbols.py"],
+    deps = [
+        "@bazel_tools//tools/python/runfiles",
+        "@implib_so//:implib_gen_lib",
+    ],
+)
+
+py_binary(
+    name = "make_stub",
+    srcs = ["make_stub.py"],
+    deps = [
+        "@bazel_tools//tools/python/runfiles",
+        "@implib_so//:implib_gen_lib",
+    ],
+)

--- a/third_party/implib_so/get_symbols.py
+++ b/third_party/implib_so/get_symbols.py
@@ -1,0 +1,38 @@
+"""Given a .so file, lists symbols that should be included in a stub.
+
+Example usage:
+$ bazel run -c opt @xla//third_party/implib_so:get_symbols
+/usr/local/cuda/lib64/libcudart.so > third_party/tsl/tsl/cuda/cudart.symbols
+"""
+
+import argparse
+import importlib
+
+# We can't import implib-gen directly because it has a dash in its name.
+implib = importlib.import_module('implib-gen')
+
+
+def _is_exported_function(s):
+  return (
+      s['Bind'] != 'LOCAL'
+      and s['Type'] == 'FUNC'
+      and s['Ndx'] != 'UND'
+      and s['Name'] not in ['', '_init', '_fini']
+      and s['Default']
+  )
+
+
+def main():
+  parser = argparse.ArgumentParser(
+      description='Extracts a list of symbols from a shared library'
+  )
+  parser.add_argument('library', help='Path to the .so file.')
+  args = parser.parse_args()
+  syms = implib.collect_syms(args.library)
+  funs = [s['Name'] for s in syms if _is_exported_function(s)]
+  for f in sorted(funs):
+    print(f)
+
+
+if __name__ == '__main__':
+  main()

--- a/third_party/implib_so/implib_so.BUILD
+++ b/third_party/implib_so/implib_so.BUILD
@@ -1,0 +1,20 @@
+# Description:
+#   Implib.so is a simple equivalent of Windows DLL import libraries for POSIX
+#   shared libraries.
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # MIT
+
+exports_files([
+    "LICENSE.txt",
+])
+
+py_library(
+    name = "implib_gen_lib",
+    srcs = ["implib-gen.py"],
+    data = glob([
+        "arch/**/*.S.tpl",
+        "arch/**/*.ini",
+    ]),
+)

--- a/third_party/implib_so/make_stub.py
+++ b/third_party/implib_so/make_stub.py
@@ -1,0 +1,68 @@
+"""Given a list of symbols, generates a stub."""
+
+import argparse
+import configparser
+import os
+import string
+
+from bazel_tools.tools.python.runfiles import runfiles
+
+r = runfiles.Create()
+
+
+def main():
+  parser = argparse.ArgumentParser(
+      description='Generates stubs for CUDA libraries.'
+  )
+  parser.add_argument('symbols', help='File containing a list of symbols.')
+  parser.add_argument(
+      '--outdir', '-o', help='Path to create wrapper at', default='.'
+  )
+  parser.add_argument(
+      '--target',
+      help='Target platform name, e.g. x86_64, aarch64.',
+      required=True,
+  )
+  args = parser.parse_args()
+
+  config_path = r.Rlocation(f'implib_so/arch/{args.target}/config.ini')
+  table_path = r.Rlocation(f'implib_so/arch/{args.target}/table.S.tpl')
+  trampoline_path = r.Rlocation(
+      f'implib_so/arch/{args.target}/trampoline.S.tpl'
+  )
+
+  cfg = configparser.ConfigParser(inline_comment_prefixes=';')
+  cfg.read(config_path)
+  ptr_size = int(cfg['Arch']['PointerSize'])
+
+  with open(args.symbols, 'r') as f:
+    funs = [s.strip() for s in f.readlines()]
+
+  # Generate assembly code, containing a table for the resolved symbols and the
+  # trampolines.
+  lib_name, _ = os.path.splitext(os.path.basename(args.symbols))
+
+  with open(os.path.join(args.outdir, f'{lib_name}.tramp.S'), 'w') as f:
+    with open(table_path, 'r') as t:
+      table_text = string.Template(t.read()).substitute(
+          lib_suffix=lib_name, table_size=ptr_size * (len(funs) + 1)
+      )
+    f.write(table_text)
+
+    with open(trampoline_path, 'r') as t:
+      tramp_tpl = string.Template(t.read())
+
+    for i, name in enumerate(funs):
+      tramp_text = tramp_tpl.substitute(
+          lib_suffix=lib_name, sym=name, offset=i * ptr_size, number=i
+      )
+      f.write(tramp_text)
+
+  # Generates a list of symbols, formatted as a list of C++ strings.
+  with open(os.path.join(args.outdir, f'{lib_name}.inc'), 'w') as f:
+    sym_names = ''.join(f'  "{name}",\n' for name in funs)
+    f.write(sym_names)
+
+
+if __name__ == '__main__':
+  main()

--- a/third_party/implib_so/workspace.bzl
+++ b/third_party/implib_so/workspace.bzl
@@ -1,0 +1,13 @@
+"""Implib.so is a simple equivalent of Windows DLL import libraries for POSIX
+shared libraries."""
+
+load("//third_party:repo.bzl", "tf_http_archive", "tf_mirror_urls")
+
+def repo():
+    tf_http_archive(
+        name = "implib_so",
+        strip_prefix = "Implib.so-2cce6cab8ff2c15f9da858ea0b68646a8d62aef2",
+        sha256 = "4ef3089969d57a5b60bb41b8212c478eaa15c56941f86d4bf5e7f98a3afd24e8",
+        urls = tf_mirror_urls("https://github.com/yugr/Implib.so/archive/2cce6cab8ff2c15f9da858ea0b68646a8d62aef2.tar.gz"),
+        build_file = "//third_party/implib_so:implib_so.BUILD",
+    )

--- a/third_party/nccl/hermetic/nccl_configure.bzl
+++ b/third_party/nccl/hermetic/nccl_configure.bzl
@@ -66,7 +66,7 @@ alias(
 alias(
   name = "nccl_headers",
   actual = select({
-      "@local_config_cuda//cuda:cuda_tools_and_libs": "@cuda_nccl//:headers",
+      "@local_config_cuda//cuda:cuda_tools": "@cuda_nccl//:headers",
       "//conditions:default": "@nccl_archive//:nccl_headers",
   }),
   visibility = ["//visibility:public"],
@@ -82,7 +82,7 @@ cc_library(
 alias(
   name = "nccl_config",
   actual = select({
-      "@local_config_cuda//cuda:cuda_tools_and_libs": ":hermetic_nccl_config",
+      "@local_config_cuda//cuda:cuda_tools": ":hermetic_nccl_config",
       "//conditions:default": "@nccl_archive//:nccl_config",
   }),
   visibility = ["//visibility:public"],
@@ -108,7 +108,7 @@ alias(
 alias(
   name = "nccl_headers",
   actual = select({
-      "@local_config_cuda//cuda:cuda_tools_and_libs": "@cuda_nccl//:headers",
+      "@local_config_cuda//cuda:cuda_tools": "@cuda_nccl//:headers",
       "//conditions:default": "@nccl_archive//:nccl_headers",
   }),
   visibility = ["//visibility:public"],
@@ -124,7 +124,7 @@ cc_library(
 alias(
   name = "nccl_config",
   actual = select({
-      "@local_config_cuda//cuda:cuda_tools_and_libs": ":hermetic_nccl_config",
+      "@local_config_cuda//cuda:cuda_tools": ":hermetic_nccl_config",
       "//conditions:default": "@nccl_archive//:nccl_config",
   }),
   visibility = ["//visibility:public"],

--- a/third_party/nvshmem/archive.patch
+++ b/third_party/nvshmem/archive.patch
@@ -1,0 +1,24 @@
+diff --git a/src/include/non_abi/device/pt-to-pt/utils_device.h b/src/include/non_abi/device/pt-to-pt/utils_device.h
+index 8342ebe06aeed8fcd5461e0fb45b36de266f7ae5..58a2a874d63e9a716544b17c9e3c55ea2b0e7e6c 100644
+--- a/src/include/non_abi/device/pt-to-pt/utils_device.h
++++ b/src/include/non_abi/device/pt-to-pt/utils_device.h
+@@ -29,6 +29,8 @@
+ 
+ #ifdef NVSHMEMI_COMM_DEVICE_UTILS_USE_PTX
+ 
++#if defined __CUDA_ARCH__
++
+ __device__ static inline uint64_t BSWAP64(uint64_t x) {
+     uint64_t ret;
+     asm volatile(
+@@ -83,6 +85,8 @@ __device__ static inline uint16_t BSWAP16(uint16_t x) {
+     return ret;
+ }
+ 
++#endif /*! __CUDA_ARCH__ */
++
+ #else /* NVSHMEMI_COMM_DEVICE_UTILS_USE_PTX */
+ 
+ #define BSWAP64(x)                                                               \
+
+

--- a/third_party/nvshmem/hermetic/nvidia_nvshmem.BUILD.tpl
+++ b/third_party/nvshmem/hermetic/nvidia_nvshmem.BUILD.tpl
@@ -1,0 +1,81 @@
+licenses(["restricted"])  # NVIDIA proprietary license
+load(
+    "@rules_ml_toolchain//third_party/xla/tsl/platform/default:cuda_build_defs.bzl",
+    "cuda_rpath_flags",
+)
+
+filegroup(
+    name = "libnvshmem_device",
+    srcs = [
+        "lib/libnvshmem_device.bc",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+%{multiline_comment}
+cc_import(
+    name = "nvshmem_host_shared_library",
+    hdrs = [":headers"],
+    shared_library = "lib/libnvshmem_host.so.%{libnvshmem_host_version}",
+)
+
+cc_import(
+    name = "nvshmem_bootstrap_uid_shared_library",
+    hdrs = [":headers"],
+    shared_library = "lib/nvshmem_bootstrap_uid.so.%{nvshmem_bootstrap_uid_version}",
+)
+
+cc_import(
+    name = "nvshmem_transport_ibrc_shared_library",
+    hdrs = [":headers"],
+    shared_library = "lib/nvshmem_transport_ibrc.so.%{nvshmem_transport_ibrc_version}",
+)
+
+# Workaround for adding nvshmem_bootstrap_uid library symlink to cc_binaries.
+cc_import(
+    name = "nvshmem_bootstrap_uid_so",
+    shared_library = "lib/nvshmem_bootstrap_uid.so",
+)
+
+# Workaround for adding nvshmem_bootstrap_uid.so to NEEDED section
+# of cc_binaries.
+genrule(
+    name = "fake_nvshmem_bootstrap_uid_cc",
+    outs = ["nvshmem_bootstrap_uid.cc"],
+    cmd = "echo '' > $@",
+)
+
+cc_binary(
+    name = "nvshmem_bootstrap_uid.so",
+    srcs = [":fake_nvshmem_bootstrap_uid_cc"],
+    linkopts = ["-Wl,-soname,nvshmem_bootstrap_uid.so"],
+    linkshared = True,
+)
+
+cc_import(
+    name = "fake_nvshmem_bootstrap_uid",
+    shared_library = ":nvshmem_bootstrap_uid.so",
+)
+%{multiline_comment}
+cc_library(
+    name = "nvshmem",
+    %{comment}deps = [
+      %{comment}":nvshmem_host_shared_library",
+      %{comment}":nvshmem_bootstrap_uid_so",
+      %{comment}":fake_nvshmem_bootstrap_uid",
+      %{comment}":nvshmem_bootstrap_uid_shared_library",
+      %{comment}":nvshmem_transport_ibrc_shared_library",
+    %{comment}],
+    %{comment}linkopts = cuda_rpath_flags("nvidia/nvshmem/lib"),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "headers",
+    %{comment}hdrs = glob([
+        %{comment}"include/**",
+    %{comment}]),
+    include_prefix = "third_party/nvshmem",
+    includes = ["include"],
+    strip_include_prefix = "include",
+)

--- a/third_party/nvshmem/hermetic/nvshmem_configure.bzl
+++ b/third_party/nvshmem/hermetic/nvshmem_configure.bzl
@@ -1,0 +1,164 @@
+# Copyright 2025 The TensorFlow Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Repository rule for hermetic NVSHMEM configuration. """
+
+load("@nvidia_nvshmem//:version.bzl", _nvshmem_version = "VERSION")
+load(
+    "//third_party/gpus/cuda/hermetic:cuda_configure.bzl",
+    "enable_cuda",
+    "use_cuda_redistributions",
+)
+load(
+    "//third_party/remote_config:common.bzl",
+    "get_cpu_value",
+)
+
+NVSHMEM_ENABLED_BUILD_CONTENT = """
+package(default_visibility = ["//visibility:public"])
+
+load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "bool_setting")
+
+# This set of flags and config_settings is needed to enable NVSHMEM dependencies
+# separately from CUDA dependencies. The reason is that NVSHMEM libraries
+# require GLIBC 2.28 and above, which we don't have on RBE runners yet.
+# TODO(ybaturina): Remove this once GLIBC 2.28 is available on RBE.
+bool_flag(
+    name = "include_nvshmem_libs",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "nvshmem_libs",
+    flag_values = {":include_nvshmem_libs": "True"},
+)
+
+bool_flag(
+    name = "override_include_nvshmem_libs",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "overrided_nvshmem_libs",
+    flag_values = {":override_include_nvshmem_libs": "True"},
+)
+
+alias(
+    name = "nvshmem_tools",
+    actual = "@local_config_cuda//:is_cuda_enabled",
+)
+
+selects.config_setting_group(
+    name = "any_nvshmem_libs",
+    match_any = [
+        ":nvshmem_libs",
+        ":overrided_nvshmem_libs",
+    ],
+)
+
+selects.config_setting_group(
+    name = "nvshmem_tools_and_libs",
+    match_all = [
+        ":any_nvshmem_libs",
+        ":nvshmem_tools",
+    ],
+)
+"""
+
+NVSHMEM_DISABLED_BUILD_CONTENT = """
+package(default_visibility = ["//visibility:public"])
+
+load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "bool_setting")
+
+bool_setting(
+    name = "true_setting",
+    build_setting_default = True,
+)
+
+bool_flag(
+    name = "include_nvshmem_libs",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "nvshmem_tools",
+    flag_values = {":true_setting": "False"},
+)
+
+config_setting(
+    name = "nvshmem_libs",
+    flag_values = {":true_setting": "False"},
+)
+
+bool_flag(
+    name = "override_include_nvshmem_libs",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "overrided_nvshmem_libs",
+    flag_values = {":true_setting": "False"},
+)
+
+selects.config_setting_group(
+    name = "any_nvshmem_libs",
+    match_any = [
+        ":nvshmem_libs",
+        ":overrided_nvshmem_libs"
+    ],
+)
+
+selects.config_setting_group(
+    name = "nvshmem_tools_and_libs",
+    match_all = [
+        ":any_nvshmem_libs",
+        ":nvshmem_tools"
+    ],
+)
+"""
+
+def _nvshmem_autoconf_impl(repository_ctx):
+    if (not enable_cuda(repository_ctx) or
+        get_cpu_value(repository_ctx) != "Linux"):
+        repository_ctx.file("BUILD", NVSHMEM_DISABLED_BUILD_CONTENT)
+        if use_cuda_redistributions(repository_ctx):
+            repository_ctx.file(
+                "nvshmem_config.h",
+                "#define NVSHMEM_VERSION \"%s\"" % _nvshmem_version,
+            )
+        else:
+            repository_ctx.file("nvshmem_config.h", "#define NVSHMEM_VERSION \"\"")
+    else:
+        repository_ctx.file(
+            "nvshmem_config.h",
+            "#define NVSHMEM_VERSION \"%s\"" % _nvshmem_version,
+        )
+        repository_ctx.file("BUILD", NVSHMEM_ENABLED_BUILD_CONTENT)
+
+nvshmem_configure = repository_rule(
+    implementation = _nvshmem_autoconf_impl,
+)
+"""Downloads and configures the hermetic NVSHMEM configuration.
+
+Add the following to your WORKSPACE file:
+
+```python
+nvshmem_configure(name = "local_config_nvshmem")
+```
+
+Args:
+  name: A unique name for this workspace rule.
+"""  # buildifier: disable=no-effect

--- a/third_party/nvshmem/hermetic/nvshmem_json_init_repository.bzl
+++ b/third_party/nvshmem/hermetic/nvshmem_json_init_repository.bzl
@@ -1,0 +1,38 @@
+# Copyright 2025 The TensorFlow Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Hermetic NVSHMEM redistributions JSON repository initialization. Consult the WORKSPACE on how to use it."""
+
+load(
+    "//third_party/gpus:nvidia_common_rules.bzl",
+    "json_init_repository",
+)
+load(
+    "//third_party/gpus/cuda/hermetic:cuda_redist_versions.bzl",
+    "MIRRORED_TARS_NVSHMEM_REDIST_JSON_DICT",
+    "NVSHMEM_REDIST_JSON_DICT",
+)
+
+def nvshmem_json_init_repository(
+        nvshmem_json_dict = NVSHMEM_REDIST_JSON_DICT,
+        mirrored_tars_nvshmem_json_dict = MIRRORED_TARS_NVSHMEM_REDIST_JSON_DICT):
+    json_init_repository(
+        name = "nvshmem_redist_json",
+        toolkit_name = "NVSHMEM",
+        json_dict = nvshmem_json_dict,
+        mirrored_tars_json_dict = mirrored_tars_nvshmem_json_dict,
+        redist_version_env_vars = ["HERMETIC_NVSHMEM_VERSION"],
+        local_path_env_var = "LOCAL_NVSHMEM_PATH",
+        use_tar_file_env_var = "USE_NVSHMEM_TAR_ARCHIVE_FILES",
+    )

--- a/third_party/nvshmem/hermetic/nvshmem_redist_init_repository.bzl
+++ b/third_party/nvshmem/hermetic/nvshmem_redist_init_repository.bzl
@@ -1,0 +1,57 @@
+# Copyright 2025 The TensorFlow Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Hermetic NVSHMEM repository initialization. Consult the WORKSPACE on how to use it."""
+
+load(
+    "//third_party/gpus:nvidia_common_rules.bzl",
+    "get_redistribution_urls",
+    "get_version_and_template_lists",
+    "redist_init_repository",
+)
+load(
+    "//third_party/gpus/cuda/hermetic:cuda_redist_versions.bzl",
+    "MIRRORED_TAR_NVSHMEM_REDIST_PATH_PREFIX",
+    "NVSHMEM_REDIST_PATH_PREFIX",
+    "NVSHMEM_REDIST_VERSIONS_TO_BUILD_TEMPLATES",
+)
+
+def nvshmem_redist_init_repository(
+        nvshmem_redistributions,
+        nvshmem_redist_path_prefix = NVSHMEM_REDIST_PATH_PREFIX,
+        mirrored_tar_nvshmem_redist_path_prefix = MIRRORED_TAR_NVSHMEM_REDIST_PATH_PREFIX,
+        redist_versions_to_build_templates = NVSHMEM_REDIST_VERSIONS_TO_BUILD_TEMPLATES):
+    # buildifier: disable=function-docstring-args
+    """Initializes NVSHMEM repository."""
+    if "libnvshmem" in nvshmem_redistributions.keys():
+        url_dict = get_redistribution_urls(nvshmem_redistributions["libnvshmem"])
+    else:
+        url_dict = {}
+    repo_data = redist_versions_to_build_templates["libnvshmem"]
+    versions, templates = get_version_and_template_lists(
+        repo_data["version_to_template"],
+    )
+    redist_init_repository(
+        name = repo_data["repo_name"],
+        versions = versions,
+        build_templates = templates,
+        url_dict = url_dict,
+        redist_path_prefix = nvshmem_redist_path_prefix,
+        mirrored_tar_redist_path_prefix = mirrored_tar_nvshmem_redist_path_prefix,
+        redist_version_env_vars = ["HERMETIC_NVSHMEM_VERSION"],
+        local_path_env_var = "LOCAL_NVSHMEM_PATH",
+        use_tar_file_env_var = "USE_NVSHMEM_TAR_ARCHIVE_FILES",
+        target_arch_env_var = "NVSHMEM_REDIST_TARGET_PLATFORM",
+        local_source_dirs = ["include", "lib", "bin"],
+    )

--- a/third_party/nvshmem/nvshmem.BUILD
+++ b/third_party/nvshmem/nvshmem.BUILD
@@ -1,0 +1,102 @@
+# NVSHMEM
+
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+
+options_substitions = {
+    "#cmakedefine NVSHMEM_COMPLEX_SUPPORT": "/* #undef NVSHMEM_COMPLEX_SUPPORT */",
+    "#cmakedefine NVSHMEM_DEBUG": "/* #undef NVSHMEM_DEBUG */",
+    "#cmakedefine NVSHMEM_DEVEL": "/* #undef NVSHMEM_DEVEL */",
+    "#cmakedefine NVSHMEM_TRACE": "/* #undef NVSHMEM_TRACE */",
+    "#cmakedefine NVSHMEM_DEFAULT_PMI2": "/* #undef NVSHMEM_DEFAULT_PMI2 */",
+    "#cmakedefine NVSHMEM_DEFAULT_PMIX": "/* #undef NVSHMEM_DEFAULT_PMIX */",
+    "#cmakedefine NVSHMEM_DEFAULT_UCX": "/* #undef NVSHMEM_DEFAULT_UCX */",
+    "#cmakedefine NVSHMEM_DISABLE_COLL_POLL": "#define NVSHMEM_DISABLE_COLL_POLL",
+    "#cmakedefine NVSHMEM_GPU_COLL_USE_LDST": "/* #undef NVSHMEM_GPU_COLL_USE_LDST */",
+    "#cmakedefine NVSHMEM_IBDEVX_SUPPORT": "/* #undef NVSHMEM_IBDEVX_SUPPORT */",
+    "#cmakedefine NVSHMEM_IBRC_SUPPORT": "#define NVSHMEM_IBRC_SUPPORT",
+    "#cmakedefine NVSHMEM_LIBFABRIC_SUPPORT": "/* #undef NVSHMEM_LIBFABRIC_SUPPORT */",
+    "#cmakedefine NVSHMEM_MPI_SUPPORT": "/* #undef NVSHMEM_MPI_SUPPORT */",
+    "#cmakedefine NVSHMEM_NVTX": "#define NVSHMEM_NVTX",
+    "#cmakedefine NVSHMEM_PMIX_SUPPORT": "/* #undef NVSHMEM_PMIX_SUPPORT */",
+    "#cmakedefine NVSHMEM_SHMEM_SUPPORT": "/* #undef NVSHMEM_SHMEM_SUPPORT */",
+    "#cmakedefine NVSHMEM_TEST_STATIC_LIB": "/* #undef NVSHMEM_TEST_STATIC_LIB */",
+    "#cmakedefine NVSHMEM_TIMEOUT_DEVICE_POLLING": "/* #undef NVSHMEM_TIMEOUT_DEVICE_POLLING */",
+    "#cmakedefine NVSHMEM_UCX_SUPPORT": "/* #undef NVSHMEM_UCX_SUPPORT */",
+    "#cmakedefine NVSHMEM_USE_DLMALLOC": "/* #undef NVSHMEM_USE_DLMALLOC */",
+    "#cmakedefine NVSHMEM_USE_NCCL": "/* #undef NVSHMEM_USE_NCCL */",
+    "#cmakedefine NVSHMEM_USE_GDRCOPY": "/* #undef NVSHMEM_USE_GDRCOPY */",
+    "#cmakedefine NVSHMEM_VERBOSE": "/* #undef NVSHMEM_VERBOSE */",
+    "#cmakedefine NVSHMEM_BUILD_TESTS": "#define NVSHMEM_BUILD_TESTS",
+    "#cmakedefine NVSHMEM_BUILD_EXAMPLES": "#define NVSHMEM_BUILD_EXAMPLES",
+    "#cmakedefine NVSHMEM_IBGDA_SUPPORT_GPUMEM_ONLY": "/* #undef NVSHMEM_IBGDA_SUPPORT_GPUMEM_ONLY */",
+    "#cmakedefine NVSHMEM_IBGDA_SUPPORT": "/* #undef NVSHMEM_IBGDA_SUPPORT */",
+    "#cmakedefine NVSHMEM_ENABLE_ALL_DEVICE_INLINING": "/* #undef NVSHMEM_ENABLE_ALL_DEVICE_INLINING */",
+}
+
+expand_template(
+    name = "nvshmem_build_options_h",
+    out = "src/include/non_abi/nvshmem_build_options.h",
+    substitutions = options_substitions,
+    template = "src/include/non_abi/nvshmem_build_options.h.in",
+)
+
+NVSHMEM_MAJOR = 3
+
+version_substitions = {
+    "@PROJECT_VERSION_MAJOR@": str(NVSHMEM_MAJOR),
+    "@PROJECT_VERSION_MINOR@": "1",
+    "@PROJECT_VERSION_PATCH@": "7",
+    "@PROJECT_VERSION_TWEAK@": "0",
+    "@TRANSPORT_VERSION_MAJOR@": "3",
+    "@TRANSPORT_VERSION_MINOR@": "0",
+    "@TRANSPORT_VERSION_PATCH@": "0",
+    "@BOOTSTRAP_VERSION_MAJOR@": "3",
+    "@BOOTSTRAP_VERSION_MINOR@": "0",
+    "@BOOTSTRAP_VERSION_PATCH@": "0",
+    "@INTERLIB_VERSION_MAJOR@": "3",
+    "@INTERLIB_VERSION_MINOR@": "0",
+    "@INTERLIB_VERSION_PATCH@": "0",
+    "@INFO_BUILD_VARS@": "",
+}
+
+expand_template(
+    name = "nvshmem_version_h",
+    out = "src/include/non_abi/nvshmem_version.h",
+    substitutions = version_substitions,
+    template = "src/include/non_abi/nvshmem_version.h.in",
+)
+
+cc_library(
+    name = "nvshmem_lib",
+    hdrs = glob([
+        "src/include/**",
+    ]) + [
+        ":nvshmem_build_options_h",
+        ":nvshmem_version_h",
+    ],
+    include_prefix = "third_party/nvshmem",
+    includes = ["src/include"],
+    strip_include_prefix = "src/include",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@rules_ml_toolchain//third_party/xla/tsl/cuda:nvshmem_stub",
+    ],
+)
+
+# This additional header allows us to determine the configured NVSHMEM version
+# without including the rest of NVSHMEM.
+write_file(
+    name = "nvshmem_config_header",
+    out = "nvshmem_config.h",
+    content = [
+        "constexpr static char XLA_NVSHMEM_VERSION[] = \"{}\";".format(NVSHMEM_MAJOR),
+    ],
+)
+
+cc_library(
+    name = "nvshmem_config",
+    hdrs = ["nvshmem_config.h"],
+    include_prefix = "third_party/nvshmem",
+    visibility = ["//visibility:public"],
+)

--- a/third_party/nvshmem/workspace.bzl
+++ b/third_party/nvshmem/workspace.bzl
@@ -1,0 +1,14 @@
+"""NVSHMEM - NVIDIA Shared Memory"""
+
+load("//third_party:repo.bzl", "tf_http_archive", "tf_mirror_urls")
+
+def repo():
+    tf_http_archive(
+        name = "nvshmem",
+        strip_prefix = "nvshmem_src",
+        sha256 = "2146ff231d9aadd2b11f324c142582f89e3804775877735dc507b4dfd70c788b",
+        urls = tf_mirror_urls("https://developer.download.nvidia.com/compute/redist/nvshmem/3.1.7/source/nvshmem_src_3.1.7-1.txz"),
+        build_file = "//third_party/nvshmem:nvshmem.BUILD",
+        patch_file = ["//third_party/nvshmem:archive.patch"],
+        type = "tar",
+    )

--- a/third_party/remote_config/common.bzl
+++ b/third_party/remote_config/common.bzl
@@ -17,6 +17,8 @@ def which(repository_ctx, program_name, allow_failure = False):
     Args:
       repository_ctx: the repository_ctx
       program_name: name of the program on the PATH
+      allow_failure: if True, an empty stdout result or output to stderr
+        is fine, otherwise either of these is an error
 
     Returns:
       The full path to a program on the execution platform.
@@ -165,10 +167,15 @@ def get_host_environ(repository_ctx, name, default_value = None):
     Args:
       repository_ctx: the repository_ctx
       name: the name of environment variable
+      default_value: the value to return if not set
 
     Returns:
       The value of the environment variable 'name' on the host platform.
     """
+    if repository_ctx.getenv(name):
+        return repository_ctx.getenv(name).strip()
+
+    # Keep here for backward compatibility. Deprecated method.
     if name in repository_ctx.os.environ:
         return repository_ctx.os.environ.get(name).strip()
 

--- a/third_party/xla/tsl/BUILD
+++ b/third_party/xla/tsl/BUILD
@@ -15,6 +15,26 @@
 # Tensor Standard Libraries - common utilities for implementing XLA.
 
 config_setting(
+    name = "linux_aarch64",
+    constraint_values =
+        [
+            "@platforms//cpu:aarch64",
+            "@platforms//os:linux",
+        ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "linux_armhf",
+    constraint_values =
+        [
+            "@platforms//cpu:armv7e-mf",
+            "@platforms//os:linux",
+        ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "linux_x86_64",
     constraint_values =
         [

--- a/third_party/xla/tsl/cuda/BUILD.bazel
+++ b/third_party/xla/tsl/cuda/BUILD.bazel
@@ -15,8 +15,15 @@
 # Description:
 #   Stubs for dynamically loading CUDA.
 
+load("@rules_ml_toolchain//third_party/xla/tsl/cuda:stub.bzl", "cuda_stub")
+
 alias(
     name = "nccl_stub",  # buildifier: disable=duplicated-name
     actual = if_cuda_libs("@cuda_nccl//:nccl", ":nccl"),
     visibility = ["//visibility:public"],
+)
+
+cuda_stub(
+    name = "nvshmem",
+    srcs = ["nvshmem.symbols"],
 )

--- a/third_party/xla/tsl/cuda/stub.bzl
+++ b/third_party/xla/tsl/cuda/stub.bzl
@@ -1,0 +1,27 @@
+"""Macros to generate CUDA library stubs from a list of symbols."""
+
+def cuda_stub(name, srcs):
+    """Generates a CUDA stub from a list of symbols.
+
+    Generates two files:
+    * library.inc, which contains a list of symbols suitable for inclusion by
+        C++, and
+    * library.tramp.S, which contains assembly-language trampolines for each
+      symbol.
+    """
+    native.genrule(
+        name = "{}_stub_gen".format(name),
+        srcs = srcs,
+        tools = ["//third_party/implib_so:make_stub"],
+        outs = [
+            "{}.inc".format(name),
+            "{}.tramp.S".format(name),
+        ],
+        tags = ["gpu"],
+        cmd = select({
+            "@rules_ml_toolchain//third_party/xla/tsl:linux_aarch64": "$(location //third_party/implib_so:make_stub) $< --outdir $(RULEDIR) --target aarch64",
+            "@rules_ml_toolchain//third_party/xla/tsl:linux_x86_64": "$(location //third_party/implib_so:make_stub) $< --outdir $(RULEDIR) --target x86_64",
+            "@rules_ml_toolchain//third_party/xla/tsl:linux_ppc64le": "$(location //third_party/implib_so:make_stub) $< --outdir $(RULEDIR) --target powerpc64le",
+            "//conditions:default": "NOT_IMPLEMENTED_FOR_THIS_PLATFORM_OR_ARCHITECTURE",
+        }),
+    )


### PR DESCRIPTION
Integrate rules_ml_toolchain `//third_party/nvshmem` package from the one found in the XLA project (https://github.com/openxla/xla/tree/main/third_party/nvshmem). Moving forward, we'll be using this updated package instead of XLA