### PR TITLE
Import 'libclang_rt.builtins.a' because LiteRT uses a compiler-specific built-in functions and these functions are not provided by GCC 8.4

### DIFF
--- a/cc_toolchain/BUILD.bazel
+++ b/cc_toolchain/BUILD.bazel
@@ -37,7 +37,7 @@ cc_toolchain_import(
         "@sysroot_linux_x86_64//:includes_system",
         "@sysroot_linux_x86_64//:glibc",
         "@sysroot_linux_x86_64//:pthread",
-        #"@llvm_linux_x86_64//:libclang_rt",
+        "@llvm_linux_x86_64//:libclang_rt",
     ],
     visibility = ["//visibility:public"],
 )
@@ -214,7 +214,7 @@ cc_toolchain_import(
         "@sysroot_linux_x86_64//:includes_system",
         "@sysroot_linux_x86_64//:glibc",
         "@sysroot_linux_x86_64//:pthread",
-        #"@llvm_linux_x86_64//:libclang_rt",
+        "@llvm_linux_x86_64//:libclang_rt",
     ],
     visibility = ["//visibility:public"],
 )

--- a/cc_toolchain/config/llvm_linux_x86_64.BUILD
+++ b/cc_toolchain/config/llvm_linux_x86_64.BUILD
@@ -96,16 +96,17 @@ cc_toolchain_import(
     visibility = ["//visibility:public"],
 )
 
-# TODO: Check LiteRT builds without this library
-#cc_toolchain_import(
-#    name = "libclang_rt",
-#    static_library = "lib/clang/{clang_version}/lib/x86_64-unknown-linux-gnu/libclang_rt.builtins.a".format(clang_version = CLANG_VERSION),
-#    target_compatible_with = select({
-#        "@platforms//os:linux": [],
-#        "@platforms//os:macos": [],
-#    }),
-#    visibility = ["//visibility:public"],
-#)
+# This library is needed for LiteRT because it uses a compiler-specific
+# built-in functions, and these functions are not provided by GCC 8.4.
+cc_toolchain_import(
+    name = "libclang_rt",
+    static_library = "lib/clang/{clang_version}/lib/x86_64-unknown-linux-gnu/libclang_rt.builtins.a".format(clang_version = CLANG_VERSION),
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "@platforms//os:macos": [],
+    }),
+    visibility = ["//visibility:public"],
+)
 
 # Use when build CUDA by Clang (NVCC doesn't need it)
 cc_library(


### PR DESCRIPTION
LiteRT needs compiler-specific built-in functions and these functions aren't supplied by GCC. 

Errors without libclang_rt.builtins.a library:

`ld.lld: error: undefined symbol: __extendhfsf2
>>> referenced by f16_test.cc
>>>               bazel-out/k8-opt/bin/tflite/experimental/shlo/_objs/f16_test/f16_test.o:(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> testing::PrintToString<shlo_ref::F16>(shlo_ref::F16 const&))
>>> referenced by f16_test.cc
>>>               bazel-out/k8-opt/bin/tflite/experimental/shlo/_objs/f16_test/f16_test.o:(shlo_ref::(anonymous namespace)::F16Test_ArithmeticOperations_Test::TestBody())
>>> referenced by f16_test.cc
>>>               bazel-out/k8-opt/bin/tflite/experimental/shlo/_objs/f16_test/f16_test.o:(shlo_ref::(anonymous namespace)::F16Test_ArithmeticOperations_Test::TestBody())
>>> referenced 173 more times

ld.lld: error: undefined symbol: __truncsfhf2
>>> referenced by f16_test.cc
>>>               bazel-out/k8-opt/bin/tflite/experimental/shlo/_objs/f16_test/f16_test.o:(shlo_ref::(anonymous namespace)::F16Test_ArithmeticOperations_Test::TestBody())
>>> referenced by f16_test.cc
>>>               bazel-out/k8-opt/bin/tflite/experimental/shlo/_objs/f16_test/f16_test.o:(shlo_ref::(anonymous namespace)::F16Test_ArithmeticOperations_Test::TestBody())
>>> referenced by f16_test.cc
>>>               bazel-out/k8-opt/bin/tflite/experimental/shlo/_objs/f16_test/f16_test.o:(shlo_ref::(anonymous namespace)::F16Test_ArithmeticOperations_Test::TestBody())
>>> referenced 41 more times`