### PR TITLE
Fix cuda_lib_header_prefix() for CPU builds.

### DIFF
--- a/third_party/gpus/nvidia_common_rules.bzl
+++ b/third_party/gpus/nvidia_common_rules.bzl
@@ -670,4 +670,6 @@ def cuda_rpath_flags(relpath):
         })
 
 def cuda_lib_header_prefix(major_version, wanted_major_version, new_header_prefix, old_header_prefix):
+    if not major_version:
+        return old_header_prefix
     return new_header_prefix if int(major_version) >= wanted_major_version else old_header_prefix


### PR DESCRIPTION
Previously it was failing because `major_version` is empty for non-CUDA builds.