### PR TITLE
Add support for building with Bzlmod

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,10 +1,11 @@
 common --noenable_bzlmod
+common:bzlmod --enable_bzlmod --noenable_workspace
 
-build --incompatible_enable_cc_toolchain_resolution     # Only for bazel 6.5: C++ rules use platforms to select toolchains when you set this
+common --incompatible_enable_cc_toolchain_resolution     # Only for bazel 6.5: C++ rules use platforms to select toolchains when you set this
 build --toolchain_resolution_debug=.*
 build --cxxopt=-std=c++17
 
-build:clang_local --noincompatible_enable_cc_toolchain_resolution
+common:clang_local --noincompatible_enable_cc_toolchain_resolution
 build:clang_local --@rules_ml_toolchain//common:enable_hermetic_cc=False
 build:clang_local --repo_env USE_HERMETIC_CC_TOOLCHAIN=0
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bazel-*
+MODULE.bazel.lock
 compare/
 .ijwb/
 .clwb/

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,62 @@
+module(name = "rules_ml_toolchain")
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "protobuf", version = "28.3", repo_name = "com_google_protobuf")
+bazel_dep(name = "rules_proto", version = "6.0.0-rc1")
+bazel_dep(name = "pybind11_bazel", version = "2.13.6")
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "abseil-cpp", version = "20240116.2", repo_name = "com_google_absl")
+bazel_dep(name = "googletest", version = "1.14.0.bcr.1", repo_name = "gtest")
+bazel_dep(name = "platforms", version = "0.0.11")
+
+pybind11_internal_configure = use_extension(
+    "@pybind11_bazel//:internal_configure.bzl",
+    "internal_configure_extension",
+)
+use_repo(pybind11_internal_configure, "pybind11")
+
+##############################################################
+# CUDA
+
+cuda_extension = use_extension("//third_party/extensions:cuda_extension.bzl", "cuda_extension")
+use_repo(cuda_extension, "local_config_cuda")
+
+cuda_json_ext = use_extension("//third_party/extensions:cuda_json_ext.bzl", "cuda_json_ext")
+use_repo(cuda_json_ext, "cuda_redist_json")
+
+cuda_redist_init_ext = use_extension("//third_party/extensions:cuda_redist_init_ext.bzl", "cuda_redist_init_ext")
+use_repo(
+    cuda_redist_init_ext,
+    "cuda_cccl",
+    "cuda_crt",
+    "cuda_cublas",
+    "cuda_cudart",
+    "cuda_cudnn",
+    "cuda_cufft",
+    "cuda_cupti",
+    "cuda_curand",
+    "cuda_cusolver",
+    "cuda_cusparse",
+    "cuda_nvcc",
+    "cuda_nvdisasm",
+    "cuda_nvjitlink",
+    "cuda_nvml",
+    "cuda_nvtx",
+    "cuda_nvvm",
+)
+
+##############################################################
+# Hermetic toolchain configuration
+
+toolchain_ext = use_extension("//third_party/extensions:toolchain_ext.bzl", "toolchain_ext")
+use_repo(
+    toolchain_ext,
+    "llvm_darwin_aarch64",
+    "llvm_linux_aarch64",
+    "llvm_linux_x86_64",
+    "sysroot_darwin_aarch64",
+    "sysroot_linux_aarch64",
+    "sysroot_linux_x86_64",
+)
+
+register_toolchains("//cc/...")

--- a/cc/deps/cc_toolchain_deps.bzl
+++ b/cc/deps/cc_toolchain_deps.bzl
@@ -14,6 +14,7 @@
 # ==============================================================================
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
 load("//common:mirrored_http_archive.bzl", "mirrored_http_archive")
 load("//third_party:repo.bzl", "tf_mirror_urls")
 load("llvm_http_archive.bzl", "llvm_http_archive")
@@ -64,7 +65,7 @@ def cc_toolchain_deps():
     #        )
 
     if "sysroot_darwin_aarch64" not in native.existing_rules():
-        native.new_local_repository(
+        new_local_repository(
             name = "sysroot_darwin_aarch64",
             build_file = "//cc/config:sysroot_darwin_aarch64.BUILD",
             path = "cc/sysroots/darwin_aarch64/MacOSX.sdk",

--- a/third_party/extensions/cuda_extension.bzl
+++ b/third_party/extensions/cuda_extension.bzl
@@ -1,0 +1,27 @@
+# Copyright 2025 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CUDA module extension."""
+
+load(
+    "//third_party/gpus/cuda/hermetic:cuda_configure.bzl",
+    "cuda_configure",
+)
+
+def _cuda_extension_impl(mctx):
+    cuda_configure(name = "local_config_cuda")
+
+cuda_extension = module_extension(
+    implementation = _cuda_extension_impl,
+)

--- a/third_party/extensions/cuda_json_ext.bzl
+++ b/third_party/extensions/cuda_json_ext.bzl
@@ -1,0 +1,24 @@
+# Copyright 2025 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module extension for cuda_redist_json."""
+
+load("//gpu/cuda:cuda_json_init_repository.bzl", "cuda_json_init_repository")
+
+def _cuda_json_ext_impl(mctx):
+    cuda_json_init_repository()
+
+cuda_json_ext = module_extension(
+    implementation = _cuda_json_ext_impl,
+)

--- a/third_party/extensions/cuda_redist_init_ext.bzl
+++ b/third_party/extensions/cuda_redist_init_ext.bzl
@@ -1,0 +1,38 @@
+# Copyright 2025 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module extension for cuda redist repositories."""
+
+load(
+    "@cuda_redist_json//:distributions.bzl",
+    "CUDA_REDISTRIBUTIONS",
+    "CUDNN_REDISTRIBUTIONS",
+)
+load(
+    "//gpu/cuda:cuda_redist_init_repositories.bzl",
+    "cuda_redist_init_repositories",
+    "cudnn_redist_init_repository",
+)
+
+def _cuda_redist_init_ext_impl(mctx):
+    cuda_redist_init_repositories(
+        cuda_redistributions = CUDA_REDISTRIBUTIONS,
+    )
+    cudnn_redist_init_repository(
+        cudnn_redistributions = CUDNN_REDISTRIBUTIONS,
+    )
+
+cuda_redist_init_ext = module_extension(
+    implementation = _cuda_redist_init_ext_impl,
+)

--- a/third_party/extensions/toolchain_ext.bzl
+++ b/third_party/extensions/toolchain_ext.bzl
@@ -1,0 +1,24 @@
+# Copyright 2025 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module extension for toolchain."""
+
+load("//cc/deps:cc_toolchain_deps.bzl", "cc_toolchain_deps")
+
+def _toolchain_module_ext_impl(mctx):
+    cc_toolchain_deps()
+
+toolchain_ext = module_extension(
+    implementation = _toolchain_module_ext_impl,
+)


### PR DESCRIPTION
Context: https://bazel.build/external/migration

This PR adds basic support for Bzlmod which allows `bazel test --config=bzlmod //cc/tests/cpu:all` to pass.

- Introduced common bazel dependencies as bazel modules
- Introduced CUDA and toolchain dependencies as module extensions located under `third_party/extensions`, which reuses repo definitions in the WORKSPACE build.

Work towards https://github.com/google-ml-infra/rules_ml_toolchain/issues/36