### PR TITLE
Set up workflows for publishing to BCR automatically

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,15 @@
+{
+  "homepage": "https://github.com/google-ml-infra/rules_ml_toolchain",
+  "maintainers": [
+    {
+      "email": "yuriit@google.com",
+      "github": "yuriivcs",
+      "name": "Yurii Topin"
+    }
+  ],
+  "versions": [],
+  "yanked_versions": {},
+  "repository": [
+    "github:google-ml-infra/rules_ml_toolchain"
+  ]
+}

--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -5,6 +5,11 @@
       "email": "yuriit@google.com",
       "github": "yuriivcs",
       "name": "Yurii Topin"
+    },
+    {
+      "email": "vam@google.com",
+      "github": "vam-google",
+      "name": "Vadym Matsishevskyi"
     }
   ],
   "versions": [],

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,12 @@
+matrix:
+  platform: ["rockylinux8", "debian11", "macos", "macos_arm64", "ubuntu2404", "windows"]
+  bazel:
+  - 7.x
+  - 8.x
+tasks:
+  verify_targets:
+    name: "Verify build targets"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@rules_cc//cc/..."

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -9,4 +9,4 @@ tasks:
     platform: ${{ platform }}
     bazel: ${{ bazel }}
     build_targets:
-      - "@rules_ml_toolchain//..."
+      - "@rules_ml_toolchain//cc/tests/cpu:all"

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -9,4 +9,4 @@ tasks:
     platform: ${{ platform }}
     bazel: ${{ bazel }}
     build_targets:
-      - "@rules_cc//cc/..."
+      - "@rules_ml_toolchain//..."

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "",
+  "strip_prefix": "{REPO}-{VERSION}",
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/rules_cc-{TAG}.tar.gz"
+}

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,5 +1,5 @@
 {
   "integrity": "",
   "strip_prefix": "{REPO}-{VERSION}",
-  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/rules_cc-{TAG}.tar.gz"
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/rules_ml_toolchain-{TAG}.tar.gz"
 }

--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -1,0 +1,24 @@
+# This file contains Bazel settings to apply on CI only.
+# It is referenced with a --bazelrc option in the call to bazel in ci.yaml
+
+# Debug where options came from
+build --announce_rc
+# This directory is configured in GitHub actions to be persisted between runs.
+# We do not enable the repository cache to cache downloaded external artifacts
+# as these are generally faster to download again than to fetch them from the
+# GitHub actions cache.
+build --disk_cache=~/.cache/bazel
+# Don't rely on test logs being easily accessible from the test runner,
+# though it makes the log noisier.
+test --test_output=errors
+# Allows tests to run bazelisk-in-bazel, since this is the cache folder used
+test --test_env=XDG_CACHE_HOME
+
+# Enable bzlmod
+common --config=bzlmod
+
+# Only build the tests
+test --build_tests_only
+
+# Skip GPU tests
+test --test_tag_filters=-gpu

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,35 @@
+name: Publish to BCR
+on:
+  # Run the publish workflow after a successful release
+  # Will be triggered from the release.yaml workflow
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+    secrets:
+      publish_token:
+        required: true
+  # In case of problems, let release engineers retry by manually dispatching
+  # the workflow from the GitHub UI
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: git tag being released
+        required: true
+        type: string
+jobs:
+  publish:
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v0.2.3
+    with:
+      tag_name: ${{ inputs.tag_name }}
+      # GitHub repository which is a fork of the upstream where the Pull Request will be opened.
+      registry_fork: Google-ML-Infra-Bazel/bazel-central-registry
+      draft: false
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+    secrets:
+      # Necessary to push to the BCR fork, and to open a pull request against a registry
+      publish_token: ${{ secrets.publish_token || secrets.BCR_PUBLISH_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,3 +33,4 @@ jobs:
     secrets:
       # Necessary to push to the BCR fork, and to open a pull request against a registry
       publish_token: ${{ secrets.publish_token || secrets.BCR_PUBLISH_TOKEN }}
+  environment: release

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,4 +33,4 @@ jobs:
     secrets:
       # Necessary to push to the BCR fork, and to open a pull request against a registry
       publish_token: ${{ secrets.publish_token || secrets.BCR_PUBLISH_TOKEN }}
-  environment: release
+    environment: release

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,4 +33,3 @@ jobs:
     secrets:
       # Necessary to push to the BCR fork, and to open a pull request against a registry
       publish_token: ${{ secrets.publish_token || secrets.BCR_PUBLISH_TOKEN }}
-    environment: release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,14 +3,14 @@ name: Release
 
 on:
   # Can be triggered from the tag.yaml workflow
-  workflow_call:
-    inputs:
-      tag_name:
-        required: true
-        type: string
-    secrets:
-      publish_token:
-        required: true
+  # workflow_call:
+  #   inputs:
+  #     tag_name:
+  #       required: true
+  #       type: string
+  #   secrets:
+  #     publish_token:
+  #       required: true
   # Or, developers can manually push a tag from their clone
   push:
     tags:
@@ -36,3 +36,4 @@ jobs:
       tag_name: ${{ inputs.tag_name || github.ref_name }}
     secrets:
       publish_token: ${{ secrets.publish_token || secrets.BCR_PUBLISH_TOKEN }}
+  environment: release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
     uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.2.3
     with:
       prerelease: false
-      release_files: rules_cc-*.tar.gz
+      release_files: rules_ml_toolchain-*.tar.gz
       tag_name: ${{ inputs.tag_name || github.ref_name }}
   publish:
     needs: release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,4 +36,4 @@ jobs:
       tag_name: ${{ inputs.tag_name || github.ref_name }}
     secrets:
       publish_token: ${{ secrets.publish_token || secrets.BCR_PUBLISH_TOKEN }}
-  environment: release
+    environment: release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,4 +36,3 @@ jobs:
       tag_name: ${{ inputs.tag_name || github.ref_name }}
     secrets:
       publish_token: ${{ secrets.publish_token || secrets.BCR_PUBLISH_TOKEN }}
-    environment: release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,38 @@
+# Automatically perform a release whenever a new "release-like" tag is pushed to the repo.
+name: Release
+
+on:
+  # Can be triggered from the tag.yaml workflow
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+    secrets:
+      publish_token:
+        required: true
+  # Or, developers can manually push a tag from their clone
+  push:
+    tags:
+      # Detect tags that look like a release.
+      # Note that we don't use a "v" prefix to help anchor this pattern.
+      # This is purely a matter of preference.
+      - "*.*.*"
+permissions:
+  id-token: write
+  attestations: write
+  contents: write
+jobs:
+  release:
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.2.3
+    with:
+      prerelease: false
+      release_files: rules_cc-*.tar.gz
+      tag_name: ${{ inputs.tag_name || github.ref_name }}
+  publish:
+    needs: release
+    uses: ./.github/workflows/publish.yaml
+    with:
+      tag_name: ${{ inputs.tag_name || github.ref_name }}
+    secrets:
+      publish_token: ${{ secrets.publish_token || secrets.BCR_PUBLISH_TOKEN }}

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail
+
+# Set by GH actions, see
+# https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+readonly TAG=$1
+# The prefix is chosen to match what GitHub generates for source archives.
+# This guarantees that users can easily switch from a released artifact to a source archive
+# with minimal differences in their code (e.g. strip_prefix remains the same)
+readonly PREFIX="rules_ml_toolchain-${TAG}"
+readonly ARCHIVE="${PREFIX}.tar.gz"
+
+# NB: configuration for 'git archive' is in /.gitattributes
+git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip > $ARCHIVE
+
+# The stdout of this program will be used as the top of the release notes for this release.
+cat << EOF
+## Using Bzlmod, just add to your \`MODULE.bazel\` file:
+
+\`\`\`starlark
+bazel_dep(name = "rules_ml_toolchain", version = "${TAG}")
+\`\`\`
+EOF


### PR DESCRIPTION
With this PR, tagging a commit with a version (e.g. 0.0.1) will automatically trigger GitHub Actions to create a release for this project and push it to BCR via a PR.

Requires
- `BCR_PUBLISH_TOKEN` to be setup correctly.
- https://github.com/google-ml-infra/rules_ml_toolchain/pull/80 for the Bzlmod build.