### PR TITLE
Restore old isystem config

### DIFF
--- a/third_party/rules_cc_toolchain/features/features.bzl
+++ b/third_party/rules_cc_toolchain/features/features.bzl
@@ -217,7 +217,7 @@ def _import_feature_impl(ctx):
     toolchain_import_info = ctx.attr.toolchain_import[CcToolchainImportInfo]
 
     include_flags = [
-        "-isystem" + inc
+        "-isystem " + inc
         for inc in toolchain_import_info
             .compilation_context.includes.to_list()
     ]


### PR DESCRIPTION
-isystem without space broke some CUDA targets. Restore previous value, but it leads to non-working SYCL. So, SYCL temporarily unavailable.