### PR TITLE
Handle '-iquote' and '-isystem' parameters in ICPX wrapper due errors

### DIFF
--- a/cc/impls/linux_x86_64_linux_x86_64_sycl/wrappers/icpx_wrapper
+++ b/cc/impls/linux_x86_64_linux_x86_64_sycl/wrappers/icpx_wrapper
@@ -87,9 +87,13 @@ def call_compiler(argv, link = False, sycl_compile = True):
   parser = ArgumentParser()
   parser.add_argument('-c', nargs=1, action='append')
   parser.add_argument('-o', nargs=1, action='append')
+  parser.add_argument('-iquote', nargs='*', action='append')
+  parser.add_argument('-isystem', nargs='*', action='append')
   args, leftover = parser.parse_known_args(argv)
 
-  flags = leftover
+  flags = (parse_list_arg(args, "-iquote") +
+           parse_list_arg(args, "-isystem") +
+           leftover)
 
   sycl_device_only_flags = ['-fsycl']
   sycl_device_only_flags.append('-fno-sycl-unnamed-lambda')
@@ -246,8 +250,28 @@ def call_compiler(argv, link = False, sycl_compile = True):
         print(' '.join([SYCL_PATH] + flags))
       return subprocess.call([ONEAPI_COMPILER] + flags)
 
+def parse_list_arg(args, name):
+  if args is None or name is None:
+    return []
+
+  prop_name = name.lstrip("-")
+  val = getattr(args, prop_name)
+  if val is None:
+    return []
+
+  args_list = []
+  for outer in val:
+    for inner in outer:
+      if inner.startswith(name):
+        args_list.append(name + (inner[len(name):].strip()))
+      elif inner.startswith("'" + name) and inner.endswith("'"):
+        args_list.append(name + (inner[len(name) + 1:len(inner) - 1].strip()))
+      else:
+        args_list.append(name + inner)
+
+  return args_list
+
 def main():
-  parser = ArgumentParser()
   parser = ArgumentParser(fromfile_prefix_chars='@')
   parser.add_argument('-sycl_compile', action='store_true')
   parser.add_argument('-link_stage', action='store_true')


### PR DESCRIPTION
Handle '-iquote' and '-isystem' parameters in ICPX wrapper due default parsing errors