### PR TITLE
[CI] Refactor BCR release to use environment

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,9 +7,9 @@ on:
       tag_name:
         required: true
         type: string
-    secrets:
-      publish_token:
+      environment:
         required: true
+        type: string
   # In case of problems, let release engineers retry by manually dispatching
   # the workflow from the GitHub UI
   workflow_dispatch:
@@ -20,16 +20,17 @@ on:
         type: string
 jobs:
   publish:
-    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v0.2.3
+    uses: MichaelHudgins/publish-to-bcr/.github/workflows/publish.yaml@e5228a53eedcfb005e348aa66e8694fa832e9703
     with:
       tag_name: ${{ inputs.tag_name }}
       # GitHub repository which is a fork of the upstream where the Pull Request will be opened.
       registry_fork: Google-ML-Infra-Bazel/bazel-central-registry
       draft: false
+      environment: ${{ inputs.environment }}
     permissions:
       attestations: write
       contents: write
       id-token: write
     secrets:
       # Necessary to push to the BCR fork, and to open a pull request against a registry
-      publish_token: ${{ secrets.publish_token || secrets.BCR_PUBLISH_TOKEN }}
+      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,16 +2,6 @@
 name: Release
 
 on:
-  # Can be triggered from the tag.yaml workflow
-  # workflow_call:
-  #   inputs:
-  #     tag_name:
-  #       required: true
-  #       type: string
-  #   secrets:
-  #     publish_token:
-  #       required: true
-  # Or, developers can manually push a tag from their clone
   push:
     tags:
       # Detect tags that look like a release.
@@ -28,11 +18,11 @@ jobs:
     with:
       prerelease: false
       release_files: rules_ml_toolchain-*.tar.gz
-      tag_name: ${{ inputs.tag_name || github.ref_name }}
+      tag_name: ${{ github.ref_name }}
   publish:
     needs: release
     uses: ./.github/workflows/publish.yaml
     with:
-      tag_name: ${{ inputs.tag_name || github.ref_name }}
-    secrets:
-      publish_token: ${{ secrets.publish_token || secrets.BCR_PUBLISH_TOKEN }}
+      tag_name: ${{ github.ref_name }}
+      environment: release
+    secrets: inherit


### PR DESCRIPTION
Refactor BCR logic to use environment only triggerable on tag.  Use my branch of bcr-publish at a locked sha until this can be upstreamed. 