### PR TITLE
Fix Bzlmod build

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -69,9 +69,15 @@ use_repo(
     "llvm_darwin_aarch64",
     "llvm_linux_aarch64",
     "llvm_linux_x86_64",
+    "llvm18_linux_x86_64",
+    "llvm19_linux_x86_64",
+    "llvm20_linux_x86_64",
+    "llvm21_linux_x86_64",
     "sysroot_darwin_aarch64",
     "sysroot_linux_aarch64",
     "sysroot_linux_x86_64",
+    "tar",
+    "xz",
 )
 
 register_toolchains("//cc/...")

--- a/cc/llvm/llvm_darwin.BUILD.tpl
+++ b/cc/llvm/llvm_darwin.BUILD.tpl
@@ -15,48 +15,48 @@
 
 alias(
     name = "all",
-    actual = "@%{llvm_repo_name}//:all",
+    actual = "@@%{llvm_repo_name}//:all",
     visibility = ["//visibility:public"],
 )
 
 alias(
     name = "clang",
-    actual = "@%{llvm_repo_name}//:clang",
+    actual = "@@%{llvm_repo_name}//:clang",
     visibility = ["//visibility:public"],
 )
 
 alias(
     name = "clang++",
-    actual = "@%{llvm_repo_name}//:clang++",
+    actual = "@@%{llvm_repo_name}//:clang++",
     visibility = ["//visibility:public"],
 )
 
 alias(
     name = "ld",
-    actual = "@%{llvm_repo_name}//:ld",
+    actual = "@@%{llvm_repo_name}//:ld",
     visibility = ["//visibility:public"],
 )
 
 alias(
     name = "ar",
-    actual = "@%{llvm_repo_name}//:ar",
+    actual = "@@%{llvm_repo_name}//:ar",
     visibility = ["//visibility:public"],
 )
 
 alias(
     name = "install_name_tool_darwin",
-    actual = "@%{llvm_repo_name}//:install_name_tool_darwin",
+    actual = "@@%{llvm_repo_name}//:install_name_tool_darwin",
     visibility = ["//visibility:public"],
 )
 
 alias(
     name = "asan_ignorelist",
-    actual = "@%{llvm_repo_name}//:asan_ignorelist",
+    actual = "@@%{llvm_repo_name}//:asan_ignorelist",
     visibility = ["//visibility:public"],
 )
 
 alias(
     name = "includes",
-    actual = "@%{llvm_repo_name}//:includes",
+    actual = "@@%{llvm_repo_name}//:includes",
     visibility = ["//visibility:public"],
 )

--- a/cc/llvm/llvm_linux.BUILD.tpl
+++ b/cc/llvm/llvm_linux.BUILD.tpl
@@ -15,62 +15,62 @@
 
 alias(
     name = "all",
-    actual = "@%{llvm_repo_name}//:all",
+    actual = "@@%{llvm_repo_name}//:all",
     visibility = ["//visibility:public"],
 )
 
 alias(
     name = "clang",
-    actual = "@%{llvm_repo_name}//:clang",
+    actual = "@@%{llvm_repo_name}//:clang",
     visibility = ["//visibility:public"],
 )
 
 alias(
     name = "clang++",
-    actual = "@%{llvm_repo_name}//:clang++",
+    actual = "@@%{llvm_repo_name}//:clang++",
     visibility = ["//visibility:public"],
 )
 
 alias(
     name = "ld",
-    actual = "@%{llvm_repo_name}//:ld",
+    actual = "@@%{llvm_repo_name}//:ld",
     visibility = ["//visibility:public"],
 )
 
 alias(
     name = "ar",
-    actual = "@%{llvm_repo_name}//:ar",
+    actual = "@@%{llvm_repo_name}//:ar",
     visibility = ["//visibility:public"],
 )
 
 alias(
     name = "ar_darwin",
-    actual = "@%{llvm_repo_name}//:ar_darwin",
+    actual = "@@%{llvm_repo_name}//:ar_darwin",
     visibility = ["//visibility:public"],
 )
 
 alias(
     name = "install_name_tool_darwin",
-    actual = "@%{llvm_repo_name}//:install_name_tool_darwin",
+    actual = "@@%{llvm_repo_name}//:install_name_tool_darwin",
     visibility = ["//visibility:public"],
 )
 
 # LLVM18 needs libtinfo.so.5 library as part of ubuntu 18 distributive
 alias(
     name = "distro_libs",
-    actual = "@%{llvm_repo_name}//:distro_libs",
+    actual = "@@%{llvm_repo_name}//:distro_libs",
     visibility = ["//visibility:public"],
 )
 
 alias(
     name = "asan_ignorelist",
-    actual = "@%{llvm_repo_name}//:asan_ignorelist",
+    actual = "@@%{llvm_repo_name}//:asan_ignorelist",
     visibility = ["//visibility:public"],
 )
 
 alias(
     name = "includes",
-    actual = "@%{llvm_repo_name}//:includes",
+    actual = "@@%{llvm_repo_name}//:includes",
     visibility = ["//visibility:public"],
 )
 
@@ -78,13 +78,13 @@ alias(
 # built-in functions, and these functions are not provided by GCC 8.4.
 alias(
     name = "libclang_rt",
-    actual = "@%{llvm_repo_name}//:libclang_rt",
+    actual = "@@%{llvm_repo_name}//:libclang_rt",
     visibility = ["//visibility:public"],
 )
 
 # Use when build CUDA by Clang (NVCC doesn't need it)
 alias(
     name = "cuda_wrappers_headers",
-    actual = "@%{llvm_repo_name}//:cuda_wrappers_headers",
+    actual = "@@%{llvm_repo_name}//:cuda_wrappers_headers",
     visibility = ["//visibility:public"],
 )

--- a/third_party/gpus/cuda/hermetic/cuda_configure.bzl
+++ b/third_party/gpus/cuda/hermetic/cuda_configure.bzl
@@ -30,7 +30,7 @@
   * `TF_SYSROOT`: The sysroot to use when compiling.
   * `HERMETIC_CUDA_VERSION`: The version of the CUDA toolkit. If not specified,
     the version will be determined by the `TF_CUDA_VERSION`.
-  * `HERMETIC_CUDA_COMPUTE_CAPABILITIES`: The CUDA compute capabilities. Default 
+  * `HERMETIC_CUDA_COMPUTE_CAPABILITIES`: The CUDA compute capabilities. Default
     is `3.5,5.2`. If not specified, the value will be determined by the
     `TF_CUDA_COMPUTE_CAPABILITIES`.
   * `TMPDIR`: specifies the directory to use for temporary files. This
@@ -474,7 +474,7 @@ def _create_local_toolchains_repository(repository_ctx):
             cuda_defines["%{cuda_toolkit_path}"] = repository_ctx.attr.nvcc_binary.workspace_root
         else:
             cuda_defines["%{cuda_toolkit_path}"] = ""
-        cuda_defines["%{cuda_nvcc_files}"] = "if_cuda([\"@{nvcc_archive}//:bin\", \"@{nvcc_archive}//:nvvm\"])".format(
+        cuda_defines["%{cuda_nvcc_files}"] = "if_cuda([\"@@{nvcc_archive}//:bin\", \"@@{nvcc_archive}//:nvvm\"])".format(
             nvcc_archive = repository_ctx.attr.nvcc_binary.repo_name,
         )
     if is_clang_compiler:


### PR DESCRIPTION
- Add missing repos in MODULE.bazel
- Use `@@` when referencing repos with their canonical name (<label>.repo_name).