### PR TITLE
Modify RPATH Support for oneAPI

### DIFF
--- a/cc/impls/linux_x86_64_linux_x86_64_sycl/features/rpath_feature.bzl
+++ b/cc/impls/linux_x86_64_linux_x86_64_sycl/features/rpath_feature.bzl
@@ -60,7 +60,7 @@ def _rpath_feature(ctx):
                     _iterate_flag_group(
                         iterate_over = "runtime_library_search_directories",
                         flags = [
-                            "-Wl,-rpath,$ORIGIN/../../%{runtime_library_search_directories}",
+                            "-Wl,-rpath,$ORIGIN/%{runtime_library_search_directories}",
                         ],
                     ),
                 ],


### PR DESCRIPTION
This PR enhances RPATH handling in the build system to ensure the correct resolution of runtime library paths.
It fixes the following error encountered during binary execution

error while loading shared libraries: libxla_Sstream_Uexecutor_Ssycl_Slibsycl_Ucontext.so: cannot open shared object file: No such file or directory

By modifying RPATH configuration, the build now correctly locates and loads all required shared libraries at runtime