### PR TITLE
Adding layering check toolchain features

### DIFF
--- a/cc/impls/linux_x86_64_linux_x86_64/BUILD
+++ b/cc/impls/linux_x86_64_linux_x86_64/BUILD
@@ -20,6 +20,7 @@
 load("//third_party/rules_cc_toolchain:toolchain_config.bzl", "cc_toolchain_config")
 load("//third_party/rules_cc_toolchain/features:cc_toolchain_import.bzl", "cc_toolchain_import")
 load("//third_party/rules_cc_toolchain/features:features.bzl", "cc_toolchain_import_feature")
+load("//cc/layering_check:build_defs.bzl", "cc_toolchain_with_cppmap")
 
 package(
     default_visibility = [
@@ -178,7 +179,7 @@ cc_toolchain_config(
     target_system_name = "local",
 )
 
-cc_toolchain(
+cc_toolchain_with_cppmap(
     name = "toolchain",
     all_files = ":all",
     ar_files = ":ar",

--- a/cc/impls/linux_x86_64_linux_x86_64_cuda/BUILD
+++ b/cc/impls/linux_x86_64_linux_x86_64_cuda/BUILD
@@ -22,6 +22,7 @@ load("@rules_cc//cc:defs.bzl", "cc_toolchain")
 load("//third_party/rules_cc_toolchain:toolchain_config.bzl", "cc_toolchain_config")
 load("//third_party/rules_cc_toolchain/features:cc_toolchain_import.bzl", "cc_toolchain_import")
 load("//third_party/rules_cc_toolchain/features:features.bzl", "cc_toolchain_import_feature")
+load("//cc/layering_check:build_defs.bzl", "cc_toolchain_with_cppmap")
 
 package(
     default_visibility = [
@@ -236,7 +237,7 @@ cc_toolchain_config(
     tool_paths = CUDA_TOOLS,
 )
 
-cc_toolchain(
+cc_toolchain_with_cppmap(
     name = "toolchain",
     all_files = ":all",
     ar_files = ":ar",

--- a/cc/layering_check/BUILD
+++ b/cc/layering_check/BUILD
@@ -1,0 +1,14 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================

--- a/cc/layering_check/build_defs.bzl
+++ b/cc/layering_check/build_defs.bzl
@@ -1,0 +1,73 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+load("@rules_cc//cc:defs.bzl", "cc_toolchain")
+
+def _generate_toolchain_cppmap_impl(ctx):
+    prefix = ctx.attr.workspace_prefix
+    if prefix and not prefix.endswith("/"):
+        prefix += "/"
+
+    lines = ['module "crosstool" [system] {']
+
+    for f in ctx.files.targets:
+        path = f.path
+
+        if "/include/" not in path and "cc/cuda/" not in path:
+            continue
+
+        # Apply prefix if file is in the main workspace
+        if f.owner.workspace_name == "":
+            path = prefix + path
+
+        # Format the line with indentation and wrapper
+        formatted_line = '  textual header "{}"'.format(path)
+        lines.append(formatted_line)
+
+    lines.append("}")
+    content = "\n".join(lines) + "\n"
+
+    ctx.actions.write(
+        output = ctx.outputs.out_file,
+        content = content,
+    )
+
+generate_toolchain_cppmap = rule(
+    implementation = _generate_toolchain_cppmap_impl,
+    attrs = {
+        "targets": attr.label_list(
+            mandatory = True,
+            allow_files = True,
+            doc = "The filegroup or list of targets to include in the module map.",
+        ),
+        "out_file": attr.output(
+            mandatory = True,
+            doc = "The name of the output file to generate.",
+        ),
+        "workspace_prefix": attr.string(
+            default = "external/rules_ml_toolchain",
+            doc = "Prefix to prepend to files belonging to the current workspace.",
+        ),
+    },
+)
+
+def cc_toolchain_with_cppmap(name, all_files, **kwargs):
+    generate_toolchain_cppmap(name = "{}_toolchain_cppmap".format(name), targets = [all_files], out_file = "{}_toolchain.cppmap".format(name))
+    cc_toolchain(
+        name = name,
+        all_files = all_files,
+        module_map = "{}_toolchain.cppmap".format(name),
+        **kwargs
+    )

--- a/third_party/gpus/cuda/hermetic/BUILD.tpl
+++ b/third_party/gpus/cuda/hermetic/BUILD.tpl
@@ -49,17 +49,35 @@ config_setting(
 # All clients including TensorFlow should use these directives.
 cc_library(
     name = "cuda_headers",
-    hdrs = [
-        "cuda/cuda_config.h",
-    ],
+    hdrs = ["cuda/cuda_config.h"],
     include_prefix = "third_party/gpus",
     includes = [
         ".",  # required to include cuda/cuda/cuda_config.h as cuda/config.h
     ],
+    # For the layering check to work we need to re-export all the headers from
+    # the subtargets. We still also need them in the dependencies for setting
+    # up the right include paths with the include prefixes.
+    textual_hdrs = [
+            "@cuda_cudart//:header_list",
+            "@cuda_cublas//:header_list",
+            "@cuda_profiler_api//:header_list",
+            "@cuda_cccl//:header_list",
+            "@cuda_nvrtc//:header_list",
+            "@cuda_nvtx//:header_list",
+            "@cuda_nvcc//:header_list",
+            "@cuda_cusolver//:header_list",
+            "@cuda_cufft//:header_list",
+            "@cuda_cusparse//:header_list",
+            "@cuda_curand//:header_list",
+            "@cuda_cupti//:header_list",
+            "@cuda_nvml//:header_list",
+            "@cuda_nvjitlink//:header_list",
+           ] + (["@cuda_crt://header_list"] if _cudart_version and int(_cudart_version)>=13 else []),
     deps = [":cudart_headers",
             ":cublas_headers",
             ":profiler_api_headers",
             ":cccl_headers",
+            ":nvrtc_headers",
             ":nvtx_headers",
             ":nvcc_headers",
             ":cusolver_headers",

--- a/third_party/gpus/cuda/hermetic/cuda_cccl.BUILD.tpl
+++ b/third_party/gpus/cuda/hermetic/cuda_cccl.BUILD.tpl
@@ -5,14 +5,21 @@ load(
 )
 load("@cuda_cudart//:version.bzl", _cudart_version = "VERSION")
 
-cc_library(
-    name = "headers",
-    hdrs = glob([
+filegroup(
+    name = "header_list",
+    srcs = glob([
         %{comment}"include" + cuda_lib_header_prefix(_cudart_version, 13, "/cccl", "") + "/cub/**",
         %{comment}"include" + cuda_lib_header_prefix(_cudart_version, 13, "/cccl", "") + "/cuda/**",
         %{comment}"include" + cuda_lib_header_prefix(_cudart_version, 13, "/cccl", "") + "/nv/**",
         %{comment}"include" + cuda_lib_header_prefix(_cudart_version, 13, "/cccl", "") + "/thrust/**",
     ]),
+    visibility = ["@local_config_cuda//cuda:__pkg__"],
+)
+
+
+cc_library(
+    name = "headers",
+    hdrs = [":header_list"],
     include_prefix = "third_party/gpus/cuda/include",
     includes = ["include" + cuda_lib_header_prefix(_cudart_version, 13, "/cccl", "")],
     strip_include_prefix = "include" + cuda_lib_header_prefix(_cudart_version, 13, "/cccl", ""),

--- a/third_party/gpus/cuda/hermetic/cuda_crt.BUILD.tpl
+++ b/third_party/gpus/cuda/hermetic/cuda_crt.BUILD.tpl
@@ -3,13 +3,19 @@ licenses(["restricted"])  # NVIDIA proprietary license
 load("@cuda_cudart//:version.bzl", _cudart_version = "VERSION")
 load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda_newer_than")
 
-cc_library(
-    name = "headers",
-    %{comment}hdrs = if_cuda_newer_than(
+filegroup(
+    name = "header_list",
+    %{comment}srcs = if_cuda_newer_than(
         %{comment}"13_0",
         %{comment}if_true = glob(["include/crt/**"]),
         %{comment}if_false = [],
     %{comment}),
+    visibility = ["@local_config_cuda//cuda:__pkg__"],
+)
+
+cc_library(
+    name = "headers",
+    hdrs = [":header_list"],
     include_prefix = "third_party/gpus/cuda/include",
     includes = ["include"],
     strip_include_prefix = "include",

--- a/third_party/gpus/cuda/hermetic/cuda_cublas.BUILD.tpl
+++ b/third_party/gpus/cuda/hermetic/cuda_cublas.BUILD.tpl
@@ -44,14 +44,21 @@ cc_library(
     %{comment}),
 )
 
-cc_library(
-    name = "headers",
-    %{comment}hdrs = [
+filegroup(
+    name = "header_list",
+    %{comment}srcs = [
         %{comment}"include/cublas.h",
         %{comment}"include/cublasLt.h",
         %{comment}"include/cublas_api.h",
         %{comment}"include/cublas_v2.h",
     %{comment}],
+    visibility = ["@local_config_cuda//cuda:__pkg__"],
+)
+
+
+cc_library(
+    name = "headers",
+    hdrs = [":header_list"],
     include_prefix = "third_party/gpus/cuda/include",
     includes = ["include"],
     strip_include_prefix = "include",

--- a/third_party/gpus/cuda/hermetic/cuda_cudart.BUILD.tpl
+++ b/third_party/gpus/cuda/hermetic/cuda_cudart.BUILD.tpl
@@ -55,9 +55,9 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 
-cc_library(
-    name = "headers",
-    %{comment}hdrs = glob([
+filegroup(
+    name = "header_list",
+    %{comment}srcs = glob([
         %{comment}"include/builtin_types.h",
         %{comment}"include/channel_descriptor.h",
         %{comment}"include/common_functions.h",
@@ -140,6 +140,12 @@ cc_library(
         %{comment}"include/vector_functions.hpp",
         %{comment}"include/vector_types.h",
     %{comment}]),
+    visibility = ["@local_config_cuda//cuda:__pkg__"],
+)
+
+cc_library(
+    name = "headers",
+    hdrs = [ ":header_list" ],
     include_prefix = "third_party/gpus/cuda/include",
     includes = ["include"],
     strip_include_prefix = "include",

--- a/third_party/gpus/cuda/hermetic/cuda_cudnn.BUILD.tpl
+++ b/third_party/gpus/cuda/hermetic/cuda_cudnn.BUILD.tpl
@@ -5,25 +5,25 @@ load(
 )
 
 %{multiline_comment}
-cc_import( 
+cc_import(
     name = "cudnn_ops",
     hdrs = [":headers"],
     shared_library = "lib/libcudnn_ops.so.%{libcudnn_ops_version}",
 )
 
-cc_import( 
+cc_import(
     name = "cudnn_cnn",
     hdrs = [":headers"],
     shared_library = "lib/libcudnn_cnn.so.%{libcudnn_cnn_version}",
 )
 
-cc_import( 
+cc_import(
     name = "cudnn_adv",
     hdrs = [":headers"],
     shared_library = "lib/libcudnn_adv.so.%{libcudnn_adv_version}",
 )
 
-cc_import( 
+cc_import(
     name = "cudnn_graph",
     hdrs = [":headers"],
     shared_library = "lib/libcudnn_graph.so.%{libcudnn_graph_version}",
@@ -55,6 +55,7 @@ cc_import(
 %{multiline_comment}
 cc_library(
     name = "cudnn",
+    hdrs = [":header_list"],
     %{comment}deps = [
       %{comment}":cudnn_engines_precompiled",
       %{comment}":cudnn_ops",
@@ -70,11 +71,17 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 
-cc_library(
-    name = "headers",
-    %{comment}hdrs = glob([
+filegroup(
+    name = "header_list",
+    %{comment}srcs = glob([
         %{comment}"include/cudnn*.h",
     %{comment}]),
+)
+
+
+cc_library(
+    name = "headers",
+    hdrs = [":header_list"],
     include_prefix = "third_party/gpus/cudnn",
     includes = ["include"],
     strip_include_prefix = "include",

--- a/third_party/gpus/cuda/hermetic/cuda_cudnn8.BUILD.tpl
+++ b/third_party/gpus/cuda/hermetic/cuda_cudnn8.BUILD.tpl
@@ -63,11 +63,17 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 
-cc_library(
-    name = "headers",
-    %{comment}hdrs = glob([
+filegroup(
+    name = "header_list",
+    %{comment}srcs = glob([
         %{comment}"include/cudnn*.h",
     %{comment}]),
+    visibility = ["@local_config_cuda//cuda:__pkg__"],
+)
+
+cc_library(
+    name = "headers",
+    hdrs = [":header_list"],
     include_prefix = "third_party/gpus/cudnn",
     includes = ["include"],
     strip_include_prefix = "include",

--- a/third_party/gpus/cuda/hermetic/cuda_cufft.BUILD.tpl
+++ b/third_party/gpus/cuda/hermetic/cuda_cufft.BUILD.tpl
@@ -26,12 +26,18 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 
-cc_library(
-    name = "headers",
-    %{comment}hdrs = glob([
-        %{comment}"include/cudalibxt.h", 
+filegroup(
+    name = "header_list",
+    %{comment}srcs = glob([
+        %{comment}"include/cudalibxt.h",
         %{comment}"include/cufft*.h"
     %{comment}]),
+    visibility = ["@local_config_cuda//cuda:__pkg__"],
+)
+
+cc_library(
+    name = "headers",
+    hdrs = [":header_list"],
     include_prefix = "third_party/gpus/cuda/include",
     includes = ["include"],
     strip_include_prefix = "include",

--- a/third_party/gpus/cuda/hermetic/cuda_cupti.BUILD.tpl
+++ b/third_party/gpus/cuda/hermetic/cuda_cupti.BUILD.tpl
@@ -27,9 +27,9 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 
-cc_library(
-    name = "headers",
-    %{comment}hdrs = glob([
+filegroup(
+    name = "header_list",
+    %{comment}srcs = glob([
         %{comment}"include/Openacc/**",
         %{comment}"include/Openmp/**",
         %{comment}"include/cuda_stdint.h",
@@ -72,6 +72,12 @@ cc_library(
         %{comment}["include/cupti_pmsampling.h",
         %{comment}"include/cupti_profiler_host.h"],
     %{comment}),
+    visibility = ["@local_config_cuda//cuda:__pkg__"],
+)
+
+cc_library(
+    name = "headers",
+    hdrs = [":header_list"],
     include_prefix = "third_party/gpus/cuda/extras/CUPTI/include",
     includes = ["include/"],
     strip_include_prefix = "include",

--- a/third_party/gpus/cuda/hermetic/cuda_curand.BUILD.tpl
+++ b/third_party/gpus/cuda/hermetic/cuda_curand.BUILD.tpl
@@ -26,9 +26,15 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 
+filegroup(
+    name = "header_list",
+    %{comment}srcs = glob(["include/curand*.h"]),
+    visibility = ["@local_config_cuda//cuda:__pkg__"],
+)
+
 cc_library(
     name = "headers",
-    %{comment}hdrs = glob(["include/curand*.h"]),
+    hdrs = [":header_list"],
     include_prefix = "third_party/gpus/cuda/include",
     includes = ["include"],
     strip_include_prefix = "include",

--- a/third_party/gpus/cuda/hermetic/cuda_cusolver.BUILD.tpl
+++ b/third_party/gpus/cuda/hermetic/cuda_cusolver.BUILD.tpl
@@ -32,11 +32,18 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 
-cc_library(
-    name = "headers",
-    %{comment}hdrs = glob([
+
+filegroup(
+    name = "header_list",
+    %{comment}srcs = glob([
         %{comment}"include/cusolver*.h",
     %{comment}]),
+    visibility = ["@local_config_cuda//cuda:__pkg__"],
+)
+
+cc_library(
+    name = "headers",
+    hdrs = [":header_list"],
     include_prefix = "third_party/gpus/cuda/include",
     includes = ["include"],
     strip_include_prefix = "include",

--- a/third_party/gpus/cuda/hermetic/cuda_cusparse.BUILD.tpl
+++ b/third_party/gpus/cuda/hermetic/cuda_cusparse.BUILD.tpl
@@ -27,9 +27,15 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 
+filegroup(
+    name = "header_list",
+    %{comment}srcs = ["include/cusparse.h"],
+    visibility = ["@local_config_cuda//cuda:__pkg__"],
+)
+
 cc_library(
     name = "headers",
-    %{comment}hdrs = ["include/cusparse.h"],
+    hdrs = [":header_list"],
     include_prefix = "third_party/gpus/cuda/include",
     includes = ["include"],
     strip_include_prefix = "include",

--- a/third_party/gpus/cuda/hermetic/cuda_nvcc.BUILD.tpl
+++ b/third_party/gpus/cuda/hermetic/cuda_nvcc.BUILD.tpl
@@ -84,9 +84,9 @@ cuda_nvcc_feature(
     ],
 )
 
-cc_library(
-    name = "headers",
-    %{comment}hdrs = glob([
+filegroup(
+    name = "header_list",
+    %{comment}srcs = glob([
         %{comment}"include/fatbinary_section.h",
         %{comment}"include/nvPTXCompiler.h",
     %{comment}]) + if_cuda_newer_than(
@@ -94,6 +94,12 @@ cc_library(
         %{comment}if_true = [],
         %{comment}if_false = glob(["include/crt/**"]),
     %{comment}),
+    visibility = ["@local_config_cuda//cuda:__pkg__"],
+)
+
+cc_library(
+    name = "headers",
+    hdrs = [":header_list"],
     include_prefix = "third_party/gpus/cuda/include",
     includes = ["include"],
     strip_include_prefix = "include",

--- a/third_party/gpus/cuda/hermetic/cuda_nvjitlink.BUILD.tpl
+++ b/third_party/gpus/cuda/hermetic/cuda_nvjitlink.BUILD.tpl
@@ -26,9 +26,15 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 
+filegroup(
+    name = "header_list",
+    %{comment}srcs = ["include/nvJitLink.h"],
+    visibility = ["@local_config_cuda//cuda:__pkg__"],
+)
+
 cc_library(
     name = "headers",
-    %{comment}hdrs = ["include/nvJitLink.h"],
+    hdrs = [":header_list"],
     include_prefix = "third_party/gpus/cuda/include",
     includes = ["include"],
     strip_include_prefix = "include",

--- a/third_party/gpus/cuda/hermetic/cuda_nvml.BUILD.tpl
+++ b/third_party/gpus/cuda/hermetic/cuda_nvml.BUILD.tpl
@@ -1,8 +1,14 @@
 licenses(["restricted"])  # NVIDIA proprietary license
 
+filegroup(
+    name = "header_list",
+    %{comment}srcs = ["include/nvml.h"],
+    visibility = ["@local_config_cuda//cuda:__pkg__"],
+)
+
 cc_library(
     name = "headers",
-    %{comment}hdrs = ["include/nvml.h"],
+    hdrs = [":header_list"],
     include_prefix = "third_party/gpus/cuda/nvml/include",
     includes = ["include"],
     strip_include_prefix = "include",

--- a/third_party/gpus/cuda/hermetic/cuda_nvrtc.BUILD.tpl
+++ b/third_party/gpus/cuda/hermetic/cuda_nvrtc.BUILD.tpl
@@ -35,11 +35,18 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 
-cc_library(
-    name = "headers",
-    %{comment}hdrs = [
+filegroup(
+    name = "header_list",
+    %{comment}srcs = [
         %{comment}"include/nvrtc.h",
     %{comment}],
+    visibility = ["@local_config_cuda//cuda:__pkg__"],
+)
+
+
+cc_library(
+    name = "headers",
+    hdrs = [":header_list"],
     include_prefix = "third_party/gpus/cuda/include",
     includes = ["include"],
     strip_include_prefix = "include",

--- a/third_party/gpus/cuda/hermetic/cuda_nvtx.BUILD.tpl
+++ b/third_party/gpus/cuda/hermetic/cuda_nvtx.BUILD.tpl
@@ -1,11 +1,18 @@
 licenses(["restricted"])  # NVIDIA proprietary license
 
-cc_library(
-    name = "headers",
-    %{comment}hdrs = glob([
+filegroup(
+    name = "header_list",
+    %{comment}srcs = glob([
         %{comment}"include/nvToolsExt*.h",
         %{comment}"include/nvtx3/**",
     %{comment}]),
+    visibility = ["@local_config_cuda//cuda:__pkg__"],
+)
+
+
+cc_library(
+    name = "headers",
+    hdrs = [":header_list"],
     include_prefix = "third_party/gpus/cuda/include",
     includes = ["include"],
     strip_include_prefix = "include",

--- a/third_party/gpus/cuda/hermetic/cuda_profiler.BUILD.tpl
+++ b/third_party/gpus/cuda/hermetic/cuda_profiler.BUILD.tpl
@@ -1,8 +1,14 @@
 licenses(["restricted"])  # NVIDIA proprietary license
 
+filegroup(
+    name = "header_list",
+    %{comment}srcs = glob(["include/**"]),
+    visibility = ["@local_config_cuda//cuda:__pkg__"],
+)
+
 cc_library(
     name = "headers",
-     %{comment}hdrs = glob(["include/**"]),
+    hdrs = [":header_list"],
     include_prefix = "third_party/gpus/cuda/include",
     includes = ["include"],
     strip_include_prefix = "include",

--- a/third_party/nccl/hermetic/cuda_nccl.BUILD.tpl
+++ b/third_party/nccl/hermetic/cuda_nccl.BUILD.tpl
@@ -17,16 +17,22 @@ cc_import(
 %{multiline_comment}
 cc_library(
     name = "nccl",
+    hdrs = [":header_list"],
     %{comment}deps = [":nccl_shared_library"],
     %{comment}linkopts = cuda_rpath_flags("nvidia/nccl/lib"),
     visibility = ["//visibility:public"],
 )
 
-cc_library(
-    name = "headers",
-    %{comment}hdrs = glob([
+filegroup(
+    name = "header_list",
+    %{comment}srcs = glob([
         %{comment}"include/nccl*.h",
     %{comment}]),
+)
+
+cc_library(
+    name = "headers",
+    hdrs = [":header_list"],
     include_prefix = "third_party/nccl",
     includes = ["include/"],
     strip_include_prefix = "include",

--- a/third_party/rules_cc_toolchain/toolchain_config.bzl
+++ b/third_party/rules_cc_toolchain/toolchain_config.bzl
@@ -33,6 +33,9 @@ load(
     "env_entry",
     "env_set",
     "feature",
+    "feature_set",
+    "flag_group",
+    "flag_set",
     "tool",
     "tool_path",
 )
@@ -103,6 +106,128 @@ def _create_artifact_name_patterns(ctx):
 
     return artifact_name_patterns
 
+def _get_layering_features(extra_module_maps, extra_flags_per_feature = {}):
+    """Returns features for layering check and header parsing."""
+
+    extra_module_map_flags = [
+        "-fmodule-map-file=" + file.path
+        for label in extra_module_maps
+        for file in label.files.to_list()
+    ]
+
+    return [
+        feature(
+            name = "module_map_home_cwd",
+            enabled = True,
+            flag_sets = [
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.c_compile,
+                        ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.cpp_header_parsing,
+                        ACTION_NAMES.cpp_module_compile,
+                    ],
+                    flag_groups = [
+                        flag_group(
+                            flags = ["-Xclang=-fmodule-map-file-home-is-cwd"],
+                        ),
+                    ],
+                ),
+            ],
+        ),
+        feature(
+            name = "use_module_maps",
+            requires = [
+              feature_set(
+                features = [
+                  "module_maps",
+                ],
+              ),
+            ],
+            flag_sets = [
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.c_compile,
+                        ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.cpp_header_parsing,
+                        ACTION_NAMES.cpp_module_compile,
+                    ],
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                "-fmodule-name=%{module_name}",
+                                "-fmodule-map-file=%{module_map_file}",
+                            ] + extra_flags_per_feature.get("use_module_maps", []),
+                        ),
+                    ],
+                ),
+            ],
+        ),
+        feature(
+            name = "module_maps",
+            enabled = True,
+            implies = [
+              "module_map_home_cwd",
+            ],
+        ),
+        feature(
+            name = "layering_check",
+            enabled = False,
+            flag_sets = [
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.c_compile,
+                        ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.cpp_header_parsing,
+                        ACTION_NAMES.cpp_module_compile,
+                    ],
+                    flag_groups = [
+                        flag_group(flags = [
+                            "-fmodules-strict-decluse",
+                            "-Wprivate-header",
+                        ]),
+                        # This list contains all of the module map dependencies
+                        # that are known to Blaze.
+                        flag_group(
+                            flags = [
+                                "-fmodule-map-file=%{dependent_module_map_files}",
+                            ],
+                            iterate_over = "dependent_module_map_files",
+                        ),
+                    ] + (
+                        # This must appear after the dependent_module_map_files
+                        # flags, because these files contain "crosstool.foo"
+                        # modules that extend the "crosstool" module, and thus
+                        # must appear after the file defining the top-level
+                        # "crosstool" module.  That file is provided to the
+                        # cc_toolchain rule as the "module_map" attribute, and
+                        # thus appears in the dependent_module_map_files list.
+                        [flag_group(flags = extra_module_map_flags)] if extra_module_map_flags else []
+                    ),
+                ),
+            ],
+            implies = ["use_module_maps"],
+        ),
+        feature(
+            name = "parse_headers",
+            flag_sets = [
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.cpp_header_parsing,
+                    ],
+                    flag_groups = [
+                        flag_group(flags = [
+                            "-xc++-header",
+                            "-fsyntax-only",
+                        ]),
+                    ],
+                ),
+            ],
+        ),
+        feature(name = "compiler_param_file"),
+        feature(name = "validates_layering_check_in_textual_hdrs", enabled = True),
+    ]
+
 def _cc_toolchain_config_impl(ctx):
     action_configs = [action_config(
         action_name = action,
@@ -139,7 +264,7 @@ def _cc_toolchain_config_impl(ctx):
             "ar": ctx.file.archiver,
             "strip": ctx.file.strip_tool,
             "in": ctx.file.install_name,
-        })],
+        })] + _get_layering_features({}),
     )
 
 cc_toolchain_config = rule(


### PR DESCRIPTION
This adds support for the layering_check feature to the C++ toolchains in this repo and prepares CUDA targets for compliance with the layering check.

1. It defines the layering_check and related features.
2. It extends the x86_64 toolchain definitions by Clang C++ modules header mapping files (`crosstool.cppmap`). This mapping file declares the system headers for each toolchain.
3. It changes the `@local_config_cuda//cuda:headers` such that it directly exports all the headers from the subtargets - which is needed for compliance with the layering check.
