### PR TITLE
Fix Bazel visibility for sycl_headers

### DIFF
--- a/gpu/sycl/sycl.BUILD
+++ b/gpu/sycl/sycl.BUILD
@@ -17,4 +17,5 @@
 alias(
     name = "sycl_headers",
     actual = "@@oneapi//:headers"
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This PR fixes a Bazel visibility error where the sycl_headers alias pointing to @@oneapi//:headers was not accessible from xla/pjrt/gpu:se_gpu_pjrt_client.
The issue is resolved by marking the alias as //visibility:public