### PR TITLE
Fix rules_ml_toolchain for XLA CUDA builds

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -138,7 +138,7 @@ use_repo(nvshmem_redist_ext, "nvidia_nvshmem")
 # SYCL configuration
 
 sycl_configure = use_extension("//extensions:sycl_configure.bzl", "sycl_configure_ext")
-use_repo(sycl_configure, "local_config_sycl")
+use_repo(sycl_configure, "local_config_sycl", "oneapi", "level_zero", "zero_loader")
 
 ##############################################################
 # ROCm configuration

--- a/extensions/cuda_redist_init.bzl
+++ b/extensions/cuda_redist_init.bzl
@@ -24,10 +24,15 @@ load(
     "cuda_redist_init_repositories",
     "cudnn_redist_init_repository",
 )
+load(
+    "//gpu/cuda:cuda_redist_versions.bzl",
+    "REDIST_VERSIONS_TO_BUILD_TEMPLATES",
+)
 
 def _cuda_redist_init_ext_impl(mctx):
     cuda_redist_init_repositories(
         cuda_redistributions = CUDA_REDISTRIBUTIONS,
+        redist_versions_to_build_templates = REDIST_VERSIONS_TO_BUILD_TEMPLATES,
     )
     cudnn_redist_init_repository(
         cudnn_redistributions = CUDNN_REDISTRIBUTIONS,

--- a/gpu/nvidia_common_rules.bzl
+++ b/gpu/nvidia_common_rules.bzl
@@ -67,7 +67,7 @@ def _get_orig_repo_name(repository_ctx):
 
     # With Bzlmod, the repo name will be something like `_main~cuda_redist_init_ext~cuda_nvml`,
     # we need to extract the original repo name.
-    return repository_ctx.name.split("~")[-1]
+    return repository_ctx.name.replace("+", "~").split("~")[-1]
 
 def get_archive_name(url):
     # buildifier: disable=function-docstring-return

--- a/gpu/sycl/dist_repo.bzl
+++ b/gpu/sycl/dist_repo.bzl
@@ -85,7 +85,7 @@ def _use_downloaded_archive(ctx):
 
     _download_distribution(ctx, dist)
 
-    if ctx.name == "level_zero":
+    if ctx.name.endswith("level_zero"):
         _handle_level_zero(ctx)
 
     build_template = ctx.attr.build_templates[dist_key]


### PR DESCRIPTION
This PR applies the patches for `rules_ml_toolchain` as specified in XLA's `MODULE.bazel`.
These changes are needed for https://github.com/openxla/xla/pull/41110.

### Summary of changes:
- **`MODULE.bazel`**: Updated `use_repo` for `sycl_configure` to include additional repositories (`oneapi`, `level_zero`, `zero_loader`).
- **`extensions/cuda_redist_init.bzl`**: Added load for `REDIST_VERSIONS_TO_BUILD_TEMPLATES` and passed it to `cuda_redist_init_repositories`.
- **`gpu/sycl/dist_repo.bzl`**: Updated condition to use `endswith("level_zero")` for repository names.
- **`gpu/nvidia_common_rules.bzl`**: Updated `_get_orig_repo_name` to handle `+` in repository names. Required by Bazel 8+