### PR TITLE
Fix alias actual path for sycl_headers

### DIFF
--- a/gpu/sycl/BUILD
+++ b/gpu/sycl/BUILD
@@ -14,7 +14,7 @@ package(default_visibility = ["//visibility:public"])
 
 alias(
     name = "sycl_headers",
-    actual = "@@oneapi//:headers",
+    actual = "@oneapi//:headers",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
`@@<canonical repo name>` should not be used directly in BUILD files. This is incompatible with Bzlmod.

Fixes https://github.com/openxla/xla/actions/runs/26097700356/job/76739793617?pr=41110

Introduced in https://github.com/google-ml-infra/rules_ml_toolchain/pull/254/changes