### PR TITLE
[ROCm] Pin GCC to hermetic sysroot in hipcc wrapper

### DIFF
--- a/cc/impls/linux_x86_64_linux_x86_64_rocm/wrappers/hipcc_wrapper
+++ b/cc/impls/linux_x86_64_linux_x86_64_rocm/wrappers/hipcc_wrapper
@@ -232,6 +232,11 @@ def InvokeHipcc(argv, log=False):
         # Local sysroot is only for host (CPU) compilation, not GPU
         if args.sysroot[0] != "/":
             gpu_compiler_options.extend(["--sysroot", args.sysroot[0]])
+            # Pin GCC to the hermetic sysroot: ROCm's clang ignores --sysroot when
+            # detecting a GCC install and would otherwise grab the host gcc-toolset.
+            gpu_compiler_options.append(
+                "--gcc-toolchain=" + os.path.join(args.sysroot[0], "usr")
+            )
     if args.g:
         gpu_compiler_options.append("-g" + "".join(sum(args.g, [])))
     if args.no_canonical_prefixes:


### PR DESCRIPTION
- ROCm's clang ignores --sysroot when locating a GCC install and picks the host's newest GCC. 
- On manylinux with an active gcc-toolset, the .cu.cc host pass pulls libstdc++ headers from outside the sysroot and fails Bazel's absolute-path-inclusion check. 
- Pass --gcc-toolchain=<sysroot>/usr in InvokeHipcc so the ROCm clang stays hermetic.