### PR TITLE
[ROCm] Add rt-libs flags for rocm toolchain, required to properly link against compiler rt

### DIFF
--- a/cc/impls/linux_x86_64_linux_x86_64_rocm/BUILD
+++ b/cc/impls/linux_x86_64_linux_x86_64_rocm/BUILD
@@ -211,6 +211,7 @@ FEATURES_ESSENTIAL = select({
     "//cc/rocm/features:rocm_defines",
     "//cc/rocm/features:rocm_hermetic",
     "//cc/rocm/features:rocm_warnings",
+    "//cc/rocm/features:rocm_compiler_rt",
 
     # Toolchain configuration
     "//third_party/rules_cc_toolchain/features:warnings",

--- a/cc/rocm/features/BUILD
+++ b/cc/rocm/features/BUILD
@@ -49,3 +49,13 @@ cc_feature(
     ],
     enabled = True,
 )
+
+# Use compiler-rt runtime library instead of libgcc
+# This is required for ROCm/HIP compilation to properly link
+# with the LLVM compiler-rt builtins
+cc_feature(
+    name = "rocm_compiler_rt",
+    compiler_flags = ["-rtlib=compiler-rt"],
+    enabled = True,
+    linker_flags = ["-rtlib=compiler-rt"],
+)


### PR DESCRIPTION
This change is derived from this analysis: 

```
The JAX hermetic build toolchain (@llvm18_linux_x86_64, LLVM 18.1.8) defaults to usinglibgcc as its compiler runtime library, meaning shared libraries it produces carry an implicit runtime dependency on libgcc_s.so.1 for low-level ABI routines. 
One such routine is__extendhfsf2, the soft-float conversion from_Float16 to float, which clang emits when compiling half-precision 
floating-point code on x86-64 targets that don't assume hardware conversion. 
On Ubuntu (where CI RBE workers run), libgcc_s.so.1 is from GCC 12+ and exports this symbol. On our manylinux_2_28 builder container (AlmaLinux 8), the system libgcc_s.so.1 is from GCC 8 and does not export it, nor doeslibgcc.a from either GCC 8 or gcc-toolset-14. This causes  libmlir_for_stubgen_common.so, compiled by the hermetic clang, 
to fail to load at runtime with undefined symbol:__extendhfsf2 when the stub generator action runs locally in the manylinux container.
```