### PR TITLE
[XLA:GPU][oneAPI] Add oneAPI BUILD template and update redist versions for 2026.0

### DIFF
--- a/gpu/sycl/BUILD.bazel
+++ b/gpu/sycl/BUILD.bazel
@@ -1,0 +1,7 @@
+exports_files([
+    "BUILD",
+    "build_defs.bzl.tpl",
+    "level_zero.BUILD",
+    "oneapi.BUILD.tpl",
+    "zero_loader.BUILD",
+])

--- a/gpu/sycl/dist_repo.bzl
+++ b/gpu/sycl/dist_repo.bzl
@@ -56,15 +56,62 @@ def _get_dist_key(ctx):
 
     return "{}_{}".format(os_id, oneapi_version)
 
-def _build_file(ctx, build_file):
-    """Utility function for writing a BUILD file.
+def _get_dist_version(dist_key):
+    return dist_key[dist_key.rfind("_") + 1:]
+
+_ONEAPI_BUILD_SUBSTITUTIONS = {
+    "2025.1": {
+        "%{advisor_version}": "2021.15",
+        "%{ccl_version}": "2021.15",
+        "%{clang_version}": "20",
+        "%{extra_lib_src_glob}": "__unused_oneapi_lib__",
+        "%{ipp_version}": "2022.1",
+        "%{libsycl_version}": "8",
+        "%{mpi_version}": "2021.15",
+        "%{oneapi_lib_paths}": ":compiler/2025.1/lib,:compiler/2025.1/compiler/lib/intel64_lin",
+        "%{oneapi_version}": "2025.1",
+        "%{tbb_version}": "2022.1",
+        "%{tcm_version}": "1.3",
+        "%{umf_version}": "0.10",
+        "%{vtune_version}": "2025.3",
+    },
+    "2026.0": {
+        "%{advisor_version}": "2026.0",
+        "%{ccl_version}": "2022.0",
+        "%{clang_version}": "22",
+        "%{extra_lib_src_glob}": "2026.0/lib/libur_adapter_level_zero_v2.so*",
+        "%{ipp_version}": "2026.0",
+        "%{libsycl_version}": "9",
+        "%{mpi_version}": "2021.18",
+        "%{oneapi_lib_paths}": ":2026.0/lib,:compiler/2026.0/lib,:compiler/2026.0/opt/compiler/lib",
+        "%{oneapi_version}": "2026.0",
+        "%{tbb_version}": "2023.0",
+        "%{tcm_version}": "1.5",
+        "%{umf_version}": "1.1",
+        "%{vtune_version}": "2026.0",
+    },
+}
+
+def _get_build_substitutions(ctx, dist_key):
+    if ctx.name != "oneapi":
+        return {}
+
+    version = _get_dist_version(dist_key)
+    if version not in _ONEAPI_BUILD_SUBSTITUTIONS:
+        fail("No oneAPI BUILD substitutions found for version {}".format(version))
+
+    return _ONEAPI_BUILD_SUBSTITUTIONS[version]
+
+def _build_file(ctx, build_template, substitutions):
+    """Utility function for writing a BUILD file from a template.
 
     Args:
       ctx: The repository context of the repository rule calling this utility function.
-      build_file: The file to use as the BUILD file for this repository. This attribute is an absolute label.
+      build_template: The template file to use as the BUILD file for this repository. This attribute is an absolute label.
+      substitutions: Template substitutions for the BUILD file.
     """
 
-    ctx.file("BUILD.bazel", ctx.read(build_file))
+    ctx.template("BUILD.bazel", build_template, substitutions)
 
 def _handle_level_zero(ctx):
     # Symlink for includes backward compatibility (example: #include <level_zero/ze_api.h>)
@@ -88,8 +135,9 @@ def _use_downloaded_archive(ctx):
     if ctx.attr.is_level_zero:
         _handle_level_zero(ctx)
 
-    build_template = ctx.attr.build_templates[dist_key]
-    _build_file(ctx, Label(build_template))
+    build_template = Label(ctx.attr.build_templates[dist_key])
+    substitutions = _get_build_substitutions(ctx, dist_key)
+    _build_file(ctx, build_template, substitutions)
 
 def _dist_repo_impl(ctx):
     local_dist_path = None

--- a/gpu/sycl/dist_repo.bzl
+++ b/gpu/sycl/dist_repo.bzl
@@ -50,7 +50,7 @@ def _get_dist_key(ctx):
     oneapi_version = _get_oneapi_version(ctx)
     os_id = _get_os(ctx)
     if not oneapi_version:
-        oneapi_version = "2025.1"
+        oneapi_version = "2026.0"
     if not os_id:
         os_id = "ubuntu_24.10"
 
@@ -62,7 +62,6 @@ def _get_dist_version(dist_key):
 _ONEAPI_BUILD_SUBSTITUTIONS = {
     "2025.1": {
         "%{advisor_version}": "2021.15",
-        "%{ccl_version}": "2021.15",
         "%{clang_version}": "20",
         "%{extra_lib_src_glob}": "__unused_oneapi_lib__",
         "%{ipp_version}": "2022.1",
@@ -77,7 +76,6 @@ _ONEAPI_BUILD_SUBSTITUTIONS = {
     },
     "2026.0": {
         "%{advisor_version}": "2026.0",
-        "%{ccl_version}": "2022.0",
         "%{clang_version}": "22",
         "%{extra_lib_src_glob}": "2026.0/lib/libur_adapter_level_zero_v2.so*",
         "%{ipp_version}": "2026.0",

--- a/gpu/sycl/dist_repo.bzl
+++ b/gpu/sycl/dist_repo.bzl
@@ -50,7 +50,7 @@ def _get_dist_key(ctx):
     oneapi_version = _get_oneapi_version(ctx)
     os_id = _get_os(ctx)
     if not oneapi_version:
-        oneapi_version = "2026.0"
+        oneapi_version = "2025.1"
     if not os_id:
         os_id = "ubuntu_24.10"
 

--- a/gpu/sycl/oneapi.BUILD.tpl
+++ b/gpu/sycl/oneapi.BUILD.tpl
@@ -51,7 +51,6 @@ package(
 ONEAPI_VERSION = "%{oneapi_version}"
 CLANG_VERSION = "%{clang_version}"
 ADVISOR_VERSION = "%{advisor_version}"
-CCL_VERSION = "%{ccl_version}"
 IPP_VERSION = "%{ipp_version}"
 MPI_VERSION = "%{mpi_version}"
 TBB_VERSION = "%{tbb_version}"
@@ -66,7 +65,6 @@ filegroup(
     name = "all",
     srcs = glob([
             "advisor/{advisor_version}/**".format(advisor_version = ADVISOR_VERSION),
-            "ccl/{ccl_version}/**".format(ccl_version = CCL_VERSION),
             "common/{oneapi_version}/**".format(oneapi_version = ONEAPI_VERSION),
             "compiler/{oneapi_version}/**".format(oneapi_version = ONEAPI_VERSION),
             "dal/2025.5/env/**",
@@ -317,35 +315,15 @@ cc_toolchain_import(
 cc_library(
     name = "headers",
     hdrs = glob([
-        "ccl/{ccl_version}/include/**".format(ccl_version = CCL_VERSION),
         "mkl/{oneapi_version}/include/**".format(oneapi_version = ONEAPI_VERSION),
         "compiler/{oneapi_version}/include/**".format(oneapi_version = ONEAPI_VERSION),
         "compiler/{oneapi_version}/opt/compiler/include/**".format(oneapi_version = ONEAPI_VERSION),
     ], allow_empty = True),
     includes = [
-        "ccl/{ccl_version}/include".format(ccl_version = CCL_VERSION),
         "mkl/{oneapi_version}/include".format(oneapi_version = ONEAPI_VERSION),
         "compiler/{oneapi_version}/include".format(oneapi_version = ONEAPI_VERSION),
         "compiler/{oneapi_version}/opt/compiler/include".format(oneapi_version = ONEAPI_VERSION),
     ],
-    visibility = ["//visibility:public"],
-)
-
-cc_library(
-    name = "ccl",
-    srcs = glob([
-        "ccl/{ccl_version}/lib/libccl.so".format(ccl_version = CCL_VERSION),
-    ], allow_empty = True),
-    data = glob([
-        "ccl/{ccl_version}/lib/libccl.so*".format(ccl_version = CCL_VERSION),
-    ], allow_empty = True),
-    hdrs = glob([
-        "ccl/{ccl_version}/include/**".format(ccl_version = CCL_VERSION),
-    ], allow_empty = True),
-    includes = [
-        "ccl/{ccl_version}/include".format(ccl_version = CCL_VERSION),
-    ],
-    linkstatic = 1,
     visibility = ["//visibility:public"],
 )
 

--- a/gpu/sycl/oneapi.BUILD.tpl
+++ b/gpu/sycl/oneapi.BUILD.tpl
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-# oneAPI variables and system paths example
+# oneAPI template variables and system paths example
 
 # config = find_sycl_config(repository_ctx)
 # sycl_basekit_path = config["sycl_basekit_path"]
@@ -21,13 +21,13 @@
 # sycl_version_number = config["sycl_version_number"]
 # sycl_basekit_version_number = config["sycl_basekit_version_number"]
 
-# mkl_include_dir: /opt/intel/oneapi/mkl/2025.2/include
-# mkl_library_dir: /opt/intel/oneapi/mkl/2025.2/lib
+# mkl_include_dir: /opt/intel/oneapi/mkl/{oneapi_version}/include
+# mkl_library_dir: /opt/intel/oneapi/mkl/{oneapi_version}/lib
 
 # sycl_basekit_path: /opt/intel/oneapi
-# sycl_basekit_version_number: 2025.2
+# sycl_basekit_version_number: {oneapi_version}
 
-# sycl_toolkit_path: /opt/intel/oneapi/compiler/2025.2
+# sycl_toolkit_path: /opt/intel/oneapi/compiler/{oneapi_version}
 # sycl_version_number: 80000
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
@@ -48,14 +48,25 @@ package(
     ],
 )
 
-ONEAPI_VERSION = "2025.1"
-CLANG_VERSION = "20"
+ONEAPI_VERSION = "%{oneapi_version}"
+CLANG_VERSION = "%{clang_version}"
+ADVISOR_VERSION = "%{advisor_version}"
+CCL_VERSION = "%{ccl_version}"
+IPP_VERSION = "%{ipp_version}"
+MPI_VERSION = "%{mpi_version}"
+TBB_VERSION = "%{tbb_version}"
+TCM_VERSION = "%{tcm_version}"
+UMF_VERSION = "%{umf_version}"
+VTUNE_VERSION = "%{vtune_version}"
+ONEAPI_LIBRARY_PATHS = "%{oneapi_lib_paths}".split(",")
+LIBSYCL_VERSION = "%{libsycl_version}"
+EXTRA_LIB_SRC_GLOB = "%{extra_lib_src_glob}"
 
 filegroup(
     name = "all",
     srcs = glob([
-            "advisor/2021.15/**",
-            "ccl/2021.15/**",
+            "advisor/{advisor_version}/**".format(advisor_version = ADVISOR_VERSION),
+            "ccl/{ccl_version}/**".format(ccl_version = CCL_VERSION),
             "common/{oneapi_version}/**".format(oneapi_version = ONEAPI_VERSION),
             "compiler/{oneapi_version}/**".format(oneapi_version = ONEAPI_VERSION),
             "dal/2025.5/env/**",
@@ -69,14 +80,14 @@ filegroup(
             "dpcpp-ct/**",
             "dpl/**",
             "installer/**",
-            "ipp/2022.1/env/**",
-            "ipp/2022.1/etc/**",
-            "ipp/2022.1/include/**",
-            "ipp/2022.1/lib/lib*",
-            "ipp/2022.1/lib/nonpic/**",
-            "ipp/2022.1/lib/pkgconfig/**",
-            "ipp/2022.1/opt/**",
-            "ipp/2022.1/share/**",
+            "ipp/{ipp_version}/env/**".format(ipp_version = IPP_VERSION),
+            "ipp/{ipp_version}/etc/**".format(ipp_version = IPP_VERSION),
+            "ipp/{ipp_version}/include/**".format(ipp_version = IPP_VERSION),
+            "ipp/{ipp_version}/lib/lib*".format(ipp_version = IPP_VERSION),
+            "ipp/{ipp_version}/lib/nonpic/**".format(ipp_version = IPP_VERSION),
+            "ipp/{ipp_version}/lib/pkgconfig/**".format(ipp_version = IPP_VERSION),
+            "ipp/{ipp_version}/opt/**".format(ipp_version = IPP_VERSION),
+            "ipp/{ipp_version}/share/**".format(ipp_version = IPP_VERSION),
             "ippcp/{oneapi_version}/env/**".format(oneapi_version = ONEAPI_VERSION),
             "ippcp/{oneapi_version}/etc/**".format(oneapi_version = ONEAPI_VERSION),
             "ippcp/{oneapi_version}/include/**".format(oneapi_version = ONEAPI_VERSION),
@@ -92,38 +103,35 @@ filegroup(
             "mkl/{oneapi_version}/lib/lib*".format(oneapi_version = ONEAPI_VERSION),
             "mkl/{oneapi_version}/lib/pkgconfig/**".format(oneapi_version = ONEAPI_VERSION),
             "mkl/{oneapi_version}/share/**".format(oneapi_version = ONEAPI_VERSION),
-            "mpi/2021.15/bin/**",
-            "mpi/2021.15/env/**",
-            "mpi/2021.15/etc/**",
-            "mpi/2021.15/include/**",
-            "mpi/2021.15/lib/lib*",
-            "mpi/2021.15/lib/mpi/**",
-            "mpi/2021.15/lib/pkgconfig/**",
-            "mpi/2021.15/opt/**",
-            "mpi/2021.15/share/**",
+            "mpi/{mpi_version}/bin/**".format(mpi_version = MPI_VERSION),
+            "mpi/{mpi_version}/env/**".format(mpi_version = MPI_VERSION),
+            "mpi/{mpi_version}/etc/**".format(mpi_version = MPI_VERSION),
+            "mpi/{mpi_version}/include/**".format(mpi_version = MPI_VERSION),
+            "mpi/{mpi_version}/lib/lib*".format(mpi_version = MPI_VERSION),
+            "mpi/{mpi_version}/lib/mpi/**".format(mpi_version = MPI_VERSION),
+            "mpi/{mpi_version}/lib/pkgconfig/**".format(mpi_version = MPI_VERSION),
+            "mpi/{mpi_version}/opt/**".format(mpi_version = MPI_VERSION),
+            "mpi/{mpi_version}/share/**".format(mpi_version = MPI_VERSION),
             "pti/0.12/**",
-            "tbb/2022.1/env/**",
-            "tbb/2022.1/etc/**",
-            "tbb/2022.1/include/**",
-            "tbb/2022.1/lib/lib*",
-            "tbb/2022.1/lib/pkgconfig/**",
-            "tbb/2022.1/share/**",
-            "tcm/1.3/**",
-            "umf/0.10/**",
-            "vtune/2025.3/**",
+            "tbb/{tbb_version}/env/**".format(tbb_version = TBB_VERSION),
+            "tbb/{tbb_version}/etc/**".format(tbb_version = TBB_VERSION),
+            "tbb/{tbb_version}/include/**".format(tbb_version = TBB_VERSION),
+            "tbb/{tbb_version}/lib/lib*".format(tbb_version = TBB_VERSION),
+            "tbb/{tbb_version}/lib/pkgconfig/**".format(tbb_version = TBB_VERSION),
+            "tbb/{tbb_version}/share/**".format(tbb_version = TBB_VERSION),
+            "tcm/{tcm_version}/**".format(tcm_version = TCM_VERSION),
+            "umf/{umf_version}/**".format(umf_version = UMF_VERSION),
+            "vtune/{vtune_version}/**".format(vtune_version = VTUNE_VERSION),
         ], allow_empty = True),
 )
 
 oneapi_feature(
     name = "binaries",
     enabled = True,
-    lib_paths = [
-        ":compiler/{oneapi_version}/lib".format(oneapi_version = ONEAPI_VERSION),
-        ":compiler/{oneapi_version}/compiler/lib/intel64_lin".format(oneapi_version = ONEAPI_VERSION),
-    ],
+    lib_paths = ONEAPI_LIBRARY_PATHS,
     icpx_path = ":compiler/{oneapi_version}/bin/icpx".format(oneapi_version = ONEAPI_VERSION),
     clang_path = ":compiler/{oneapi_version}/bin/compiler/clang".format(oneapi_version = ONEAPI_VERSION),
-    version = "2025.1",
+    version = ONEAPI_VERSION,
     verbose = True
 )
 
@@ -323,31 +331,33 @@ cc_library(
 
 cc_library(
     name = "libs",
-    srcs = glob([
-        "compiler/{oneapi_version}/lib/libsycl.so.8".format(oneapi_version = ONEAPI_VERSION),
-        "compiler/{oneapi_version}/lib/libirc.so".format(oneapi_version = ONEAPI_VERSION),
-        "compiler/{oneapi_version}/lib/libur_loader.so.0".format(oneapi_version = ONEAPI_VERSION),
-        "compiler/{oneapi_version}/lib/libimf.so".format(oneapi_version = ONEAPI_VERSION),
-        "compiler/{oneapi_version}/lib/libintlc.so.5".format(oneapi_version = ONEAPI_VERSION),
-        "compiler/{oneapi_version}/lib/libsvml.so".format(oneapi_version = ONEAPI_VERSION),
-        "compiler/{oneapi_version}/lib/libirng.so".format(oneapi_version = ONEAPI_VERSION),
-        "compiler/{oneapi_version}/lib/libOpenCL.so*".format(oneapi_version = ONEAPI_VERSION),
-        "compiler/{oneapi_version}/lib/libmpi.so*".format(oneapi_version = ONEAPI_VERSION),
-        "{oneapi_version}/lib/libumf.so*".format(oneapi_version = ONEAPI_VERSION),
-        "{oneapi_version}/lib/libhwloc.so.15".format(oneapi_version = ONEAPI_VERSION),
-        "{oneapi_version}/lib/libur_loader.so*".format(oneapi_version = ONEAPI_VERSION),
-        "{oneapi_version}/lib/libur_adapter_level_zero.so*".format(oneapi_version = ONEAPI_VERSION),
-        "{oneapi_version}/lib/libur_adapter_opencl.so*".format(oneapi_version = ONEAPI_VERSION),
-        "mkl/{oneapi_version}/lib/libmkl_intel_ilp64.so*".format(oneapi_version = ONEAPI_VERSION),
-        "mkl/{oneapi_version}/lib/libmkl_sequential.so*".format(oneapi_version = ONEAPI_VERSION),
-        "mkl/{oneapi_version}/lib/libmkl_core.so*".format(oneapi_version = ONEAPI_VERSION),
-        "mkl/{oneapi_version}/lib/libmkl_sycl_blas.so*".format(oneapi_version = ONEAPI_VERSION),
-        "mkl/{oneapi_version}/lib/libmkl_sycl_dft.so*".format(oneapi_version = ONEAPI_VERSION),
-        "mkl/{oneapi_version}/lib/libmkl_sycl_lapack.so*".format(oneapi_version = ONEAPI_VERSION),
-        "mkl/{oneapi_version}/lib/libmkl_sycl_rng.so*".format(oneapi_version = ONEAPI_VERSION),
-        "mkl/{oneapi_version}/lib/libmkl_sycl_sparse.so*".format(oneapi_version = ONEAPI_VERSION),
-
-   ],
+    srcs = glob(
+        [
+            "compiler/{oneapi_version}/lib/libsycl.so.{libsycl_version}"
+                .format(oneapi_version = ONEAPI_VERSION, libsycl_version = LIBSYCL_VERSION),
+            "compiler/{oneapi_version}/lib/libirc.so".format(oneapi_version = ONEAPI_VERSION),
+            "compiler/{oneapi_version}/lib/libur_loader.so.0".format(oneapi_version = ONEAPI_VERSION),
+            "compiler/{oneapi_version}/lib/libimf.so".format(oneapi_version = ONEAPI_VERSION),
+            "compiler/{oneapi_version}/lib/libintlc.so.5".format(oneapi_version = ONEAPI_VERSION),
+            "compiler/{oneapi_version}/lib/libsvml.so".format(oneapi_version = ONEAPI_VERSION),
+            "compiler/{oneapi_version}/lib/libirng.so".format(oneapi_version = ONEAPI_VERSION),
+            "compiler/{oneapi_version}/lib/libOpenCL.so*".format(oneapi_version = ONEAPI_VERSION),
+            "compiler/{oneapi_version}/lib/libmpi.so*".format(oneapi_version = ONEAPI_VERSION),
+            "{oneapi_version}/lib/libumf.so*".format(oneapi_version = ONEAPI_VERSION),
+            "{oneapi_version}/lib/libhwloc.so.15".format(oneapi_version = ONEAPI_VERSION),
+            "{oneapi_version}/lib/libur_loader.so*".format(oneapi_version = ONEAPI_VERSION),
+            "{oneapi_version}/lib/libur_adapter_level_zero.so*".format(oneapi_version = ONEAPI_VERSION),
+            EXTRA_LIB_SRC_GLOB,
+            "{oneapi_version}/lib/libur_adapter_opencl.so*".format(oneapi_version = ONEAPI_VERSION),
+            "mkl/{oneapi_version}/lib/libmkl_intel_ilp64.so*".format(oneapi_version = ONEAPI_VERSION),
+            "mkl/{oneapi_version}/lib/libmkl_sequential.so*".format(oneapi_version = ONEAPI_VERSION),
+            "mkl/{oneapi_version}/lib/libmkl_core.so*".format(oneapi_version = ONEAPI_VERSION),
+            "mkl/{oneapi_version}/lib/libmkl_sycl_blas.so*".format(oneapi_version = ONEAPI_VERSION),
+            "mkl/{oneapi_version}/lib/libmkl_sycl_dft.so*".format(oneapi_version = ONEAPI_VERSION),
+            "mkl/{oneapi_version}/lib/libmkl_sycl_lapack.so*".format(oneapi_version = ONEAPI_VERSION),
+            "mkl/{oneapi_version}/lib/libmkl_sycl_rng.so*".format(oneapi_version = ONEAPI_VERSION),
+            "mkl/{oneapi_version}/lib/libmkl_sycl_sparse.so*".format(oneapi_version = ONEAPI_VERSION),
+        ],
         allow_empty = True,
     ),
     linkopts = [

--- a/gpu/sycl/oneapi.BUILD.tpl
+++ b/gpu/sycl/oneapi.BUILD.tpl
@@ -317,15 +317,35 @@ cc_toolchain_import(
 cc_library(
     name = "headers",
     hdrs = glob([
+        "ccl/{ccl_version}/include/**".format(ccl_version = CCL_VERSION),
         "mkl/{oneapi_version}/include/**".format(oneapi_version = ONEAPI_VERSION),
         "compiler/{oneapi_version}/include/**".format(oneapi_version = ONEAPI_VERSION),
         "compiler/{oneapi_version}/opt/compiler/include/**".format(oneapi_version = ONEAPI_VERSION),
     ], allow_empty = True),
     includes = [
+        "ccl/{ccl_version}/include".format(ccl_version = CCL_VERSION),
         "mkl/{oneapi_version}/include".format(oneapi_version = ONEAPI_VERSION),
         "compiler/{oneapi_version}/include".format(oneapi_version = ONEAPI_VERSION),
         "compiler/{oneapi_version}/opt/compiler/include".format(oneapi_version = ONEAPI_VERSION),
     ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "ccl",
+    srcs = glob([
+        "ccl/{ccl_version}/lib/libccl.so".format(ccl_version = CCL_VERSION),
+    ], allow_empty = True),
+    data = glob([
+        "ccl/{ccl_version}/lib/libccl.so*".format(ccl_version = CCL_VERSION),
+    ], allow_empty = True),
+    hdrs = glob([
+        "ccl/{ccl_version}/include/**".format(ccl_version = CCL_VERSION),
+    ], allow_empty = True),
+    includes = [
+        "ccl/{ccl_version}/include".format(ccl_version = CCL_VERSION),
+    ],
+    linkstatic = 1,
     visibility = ["//visibility:public"],
 )
 

--- a/gpu/sycl/sycl_redist_versions.bzl
+++ b/gpu/sycl/sycl_redist_versions.bzl
@@ -30,9 +30,19 @@ REDIST_DICT = {
             "2213104bd122336551aa144512e7ab99e4a84220e77980b5f346edc14ebd458a",
             "oneapi",
         ],
+        "ubuntu_24.04_2026.0": [
+            "https://github.com/neudinger/rules-ml-toolchain-redists/releases/download/oneapi-v2026.0.0.198-ubuntu_24.04-x86_64/intel-oneapi-toolkit-2026.0.0.198-ubuntu_24.04-x86_64.tar.zst",
+            "bd6ee118d17d05078607ca5609fecefb84197ebd1a2c0f24eb6e9ea63f1719a1",
+            "oneapi",
+        ],
     },
     "level_zero": {
         "ubuntu_24.10_2025.1": [
+            "https://d3q76yfpnzmnjx.cloudfront.net/level-zero-1.21.10.tar.gz",
+            "e0ff1c6cb9b551019579a2dd35c3a611240c1b60918c75345faf9514142b9c34",
+            "level-zero-1.21.10",
+        ],
+        "ubuntu_24.04_2026.0": [
             "https://d3q76yfpnzmnjx.cloudfront.net/level-zero-1.21.10.tar.gz",
             "e0ff1c6cb9b551019579a2dd35c3a611240c1b60918c75345faf9514142b9c34",
             "level-zero-1.21.10",
@@ -44,6 +54,11 @@ REDIST_DICT = {
             "71cbfd8ac59e1231f013e827ea8efe6cf5da36fad771da2e75e202423bd6b82e",
             "",
         ],
+        "ubuntu_24.04_2026.0": [
+            "https://d3q76yfpnzmnjx.cloudfront.net/ze_loader_libs.tar.gz",
+            "71cbfd8ac59e1231f013e827ea8efe6cf5da36fad771da2e75e202423bd6b82e",
+            "",
+        ],
     },
 }
 
@@ -51,21 +66,24 @@ BUILD_TEMPLATES = {
     "oneapi": {
         "repo_name": "oneapi",
         "version_to_template": {
-            "ubuntu_24.10_2025.1": "//gpu/sycl:oneapi.BUILD",
-            "ubuntu_24.04_2025.1": "//gpu/sycl:oneapi.BUILD",
-            "ubuntu_22.04_2025.1": "//gpu/sycl:oneapi.BUILD",
+            "ubuntu_24.10_2025.1": "//gpu/sycl:oneapi.BUILD.tpl",
+            "ubuntu_24.04_2025.1": "//gpu/sycl:oneapi.BUILD.tpl",
+            "ubuntu_22.04_2025.1": "//gpu/sycl:oneapi.BUILD.tpl",
+            "ubuntu_24.04_2026.0": "//gpu/sycl:oneapi.BUILD.tpl",
         },
     },
     "level_zero": {
         "repo_name": "level_zero",
         "version_to_template": {
             "ubuntu_24.10_2025.1": "//gpu/sycl:level_zero.BUILD",
+            "ubuntu_24.04_2026.0": "//gpu/sycl:level_zero.BUILD",
         },
     },
     "zero_loader": {
         "repo_name": "zero_loader",
         "version_to_template": {
             "ubuntu_24.10_2025.1": "//gpu/sycl:zero_loader.BUILD",
+            "ubuntu_24.04_2026.0": "//gpu/sycl:zero_loader.BUILD",
         },
     },
 }

--- a/gpu/sycl/sycl_redist_versions.bzl
+++ b/gpu/sycl/sycl_redist_versions.bzl
@@ -30,9 +30,9 @@ REDIST_DICT = {
             "2213104bd122336551aa144512e7ab99e4a84220e77980b5f346edc14ebd458a",
             "oneapi",
         ],
-        "ubuntu_24.04_2026.0": [
-            "https://github.com/neudinger/rules-ml-toolchain-redists/releases/download/oneapi-v2026.0.0.198-ubuntu_24.04-x86_64/intel-oneapi-toolkit-2026.0.0.198-ubuntu_24.04-x86_64.tar.zst",
-            "bd6ee118d17d05078607ca5609fecefb84197ebd1a2c0f24eb6e9ea63f1719a1",
+        "ubuntu_24.10_2026.0": [
+            "https://d3q76yfpnzmnjx.cloudfront.net/intel-oneapi-base-toolkit-2026.0.0.tar.gz",
+            "1d8633ef69020ecb8f495979c56c6a9db0a3d1343a0697863dcf7fba097a369b",
             "oneapi",
         ],
     },
@@ -42,7 +42,7 @@ REDIST_DICT = {
             "e0ff1c6cb9b551019579a2dd35c3a611240c1b60918c75345faf9514142b9c34",
             "level-zero-1.21.10",
         ],
-        "ubuntu_24.04_2026.0": [
+        "ubuntu_24.10_2026.0": [
             "https://d3q76yfpnzmnjx.cloudfront.net/level-zero-1.21.10.tar.gz",
             "e0ff1c6cb9b551019579a2dd35c3a611240c1b60918c75345faf9514142b9c34",
             "level-zero-1.21.10",
@@ -54,7 +54,7 @@ REDIST_DICT = {
             "71cbfd8ac59e1231f013e827ea8efe6cf5da36fad771da2e75e202423bd6b82e",
             "",
         ],
-        "ubuntu_24.04_2026.0": [
+        "ubuntu_24.10_2026.0": [
             "https://d3q76yfpnzmnjx.cloudfront.net/ze_loader_libs.tar.gz",
             "71cbfd8ac59e1231f013e827ea8efe6cf5da36fad771da2e75e202423bd6b82e",
             "",
@@ -69,21 +69,21 @@ BUILD_TEMPLATES = {
             "ubuntu_24.10_2025.1": "//gpu/sycl:oneapi.BUILD.tpl",
             "ubuntu_24.04_2025.1": "//gpu/sycl:oneapi.BUILD.tpl",
             "ubuntu_22.04_2025.1": "//gpu/sycl:oneapi.BUILD.tpl",
-            "ubuntu_24.04_2026.0": "//gpu/sycl:oneapi.BUILD.tpl",
+            "ubuntu_24.10_2026.0": "//gpu/sycl:oneapi.BUILD.tpl",
         },
     },
     "level_zero": {
         "repo_name": "level_zero",
         "version_to_template": {
             "ubuntu_24.10_2025.1": "//gpu/sycl:level_zero.BUILD",
-            "ubuntu_24.04_2026.0": "//gpu/sycl:level_zero.BUILD",
+            "ubuntu_24.10_2026.0": "//gpu/sycl:level_zero.BUILD",
         },
     },
     "zero_loader": {
         "repo_name": "zero_loader",
         "version_to_template": {
             "ubuntu_24.10_2025.1": "//gpu/sycl:zero_loader.BUILD",
-            "ubuntu_24.04_2026.0": "//gpu/sycl:zero_loader.BUILD",
+            "ubuntu_24.10_2026.0": "//gpu/sycl:zero_loader.BUILD",
         },
     },
 }


### PR DESCRIPTION

Add :
- Support for Intel oneAPI 2026.0 redistributable packages on Ubuntu 24.10.
- A reusable BUILD template for oneAPI packages, so package layout can be shared across supported oneAPI versions in the same style as CUDA/ROCm.
- Toolchain-owned hermetic SYCL defaults for oneAPI 2026.0 and Ubuntu 24.10.
- Removal of bundled oneCCL exposure from `@oneapi`; oneCCL is expected to be built separately for GPU. See openxla/xla#42595.


Context:

To update ZML to fully support the latest intel GPU and the lattest oneAPI toolkit, we need to update the XLA project with oneAPI 2026 therefore XLA project need rules_ml_toolchain with oneAPI 2026.

Redistributable source:
For oneAPI 2026.0 this PR uses:
https://d3q76yfpnzmnjx.cloudfront.net/intel-oneapi-base-toolkit-2026.0.0.tar.gz

Validation:

```bash
bazel build \
    --config=sycl_hermetic \
    --repo_env=ONEAPI_VERSION=2026.0 \
    --repo_env=OS=ubuntu_24.10 \
    @oneapi//:all @oneapi//:headers @oneapi//:libs @level_zero//:all @zero_loader//:all
```

Notes:

- `@oneapi//:ccl` is intentionally no longer declared.
- `@oneapi//:headers` no longer exports oneCCL headers.
