### PR TITLE
Add MKL Headers and Libraries to oneAPI Toolchain

### DIFF
--- a/gpu/sycl/level_zero.BUILD
+++ b/gpu/sycl/level_zero.BUILD
@@ -44,9 +44,11 @@ cc_library(
     name = "headers",
     hdrs = glob([
         "level_zero/**/*",
+        "include/**/*",
     ], allow_empty = True),
     includes = [
         ".",
+        "include",
     ],
     visibility = ["//visibility:public"],
 )

--- a/gpu/sycl/oneapi.BUILD
+++ b/gpu/sycl/oneapi.BUILD
@@ -278,6 +278,16 @@ cc_toolchain_import(
 )
 
 cc_toolchain_import(
+    name = "includes_mkl",
+    hdrs = glob([
+        "mkl/{oneapi_version}/include/**".format(oneapi_version = ONEAPI_VERSION),
+    ]),
+    includes = [
+        "mkl/{oneapi_version}/include".format(oneapi_version = ONEAPI_VERSION),
+    ],
+)
+
+cc_toolchain_import(
     name = "core",
     additional_libs = glob([
         "compiler/{oneapi_version}/lib/*".format(oneapi_version = ONEAPI_VERSION),
@@ -285,13 +295,26 @@ cc_toolchain_import(
     visibility = ["//visibility:public"],
 )
 
+cc_toolchain_import(
+    name = "mkl",
+    additional_libs = glob([
+        "mkl/{oneapi_version}/lib/libmkl_intel_ilp64.s*".format(oneapi_version = ONEAPI_VERSION),
+        "mkl/{oneapi_version}/lib/libmkl_sequential.s*".format(oneapi_version = ONEAPI_VERSION),
+        "mkl/{oneapi_version}/lib/libmkl_core.s*".format(oneapi_version = ONEAPI_VERSION),
+        "mkl/{oneapi_version}/lib/libmkl_sycl_*".format(oneapi_version = ONEAPI_VERSION),
+    ]),
+    visibility = ["//visibility:public"],
+)
+
 cc_library(
     name = "headers",
     hdrs = glob([
+        "mkl/{oneapi_version}/include/**".format(oneapi_version = ONEAPI_VERSION),
         "compiler/{oneapi_version}/include/**".format(oneapi_version = ONEAPI_VERSION),
         "compiler/{oneapi_version}/opt/compiler/include/**".format(oneapi_version = ONEAPI_VERSION),
     ], allow_empty = True),
     includes = [
+        "mkl/{oneapi_version}/include".format(oneapi_version = ONEAPI_VERSION),
         "compiler/{oneapi_version}/include".format(oneapi_version = ONEAPI_VERSION),
         "compiler/{oneapi_version}/opt/compiler/include".format(oneapi_version = ONEAPI_VERSION),
     ],
@@ -309,13 +332,27 @@ cc_library(
         "compiler/{oneapi_version}/lib/libsvml.so".format(oneapi_version = ONEAPI_VERSION),
         "compiler/{oneapi_version}/lib/libirng.so".format(oneapi_version = ONEAPI_VERSION),
         "compiler/{oneapi_version}/lib/libOpenCL.so*".format(oneapi_version = ONEAPI_VERSION),
+        "compiler/{oneapi_version}/lib/libmpi.so*".format(oneapi_version = ONEAPI_VERSION),
         "{oneapi_version}/lib/libumf.so*".format(oneapi_version = ONEAPI_VERSION),
         "{oneapi_version}/lib/libhwloc.so.15".format(oneapi_version = ONEAPI_VERSION),
         "{oneapi_version}/lib/libur_loader.so*".format(oneapi_version = ONEAPI_VERSION),
         "{oneapi_version}/lib/libur_adapter_level_zero.so*".format(oneapi_version = ONEAPI_VERSION),
         "{oneapi_version}/lib/libur_adapter_opencl.so*".format(oneapi_version = ONEAPI_VERSION),
-    ], allow_empty = True),
-    linkopts = ["-Wl,-Bstatic,-lsvml,-lirng,-limf,-lirc,-lirc_s,-Bdynamic"],
+        "mkl/{oneapi_version}/lib/libmkl_intel_ilp64.so*".format(oneapi_version = ONEAPI_VERSION),
+        "mkl/{oneapi_version}/lib/libmkl_sequential.so*".format(oneapi_version = ONEAPI_VERSION),
+        "mkl/{oneapi_version}/lib/libmkl_core.so*".format(oneapi_version = ONEAPI_VERSION),
+        "mkl/{oneapi_version}/lib/libmkl_sycl_blas.so*".format(oneapi_version = ONEAPI_VERSION),
+        "mkl/{oneapi_version}/lib/libmkl_sycl_dft.so*".format(oneapi_version = ONEAPI_VERSION),
+        "mkl/{oneapi_version}/lib/libmkl_sycl_lapack.so*".format(oneapi_version = ONEAPI_VERSION),
+        "mkl/{oneapi_version}/lib/libmkl_sycl_rng.so*".format(oneapi_version = ONEAPI_VERSION),
+        "mkl/{oneapi_version}/lib/libmkl_sycl_sparse.so*".format(oneapi_version = ONEAPI_VERSION),
+
+   ],
+        allow_empty = True,
+    ),
+    linkopts = [
+        "-Wl,-Bstatic,-lsvml,-lirng,-limf,-lirc,-lirc_s,-Bdynamic",
+    ],
     linkstatic = 1,
     visibility = ["//visibility:public"],
 )

--- a/gpu/sycl/zero_loader.BUILD
+++ b/gpu/sycl/zero_loader.BUILD
@@ -17,6 +17,7 @@
 # l0_include_dir: /usr/include/level_zero
 # l0_library_dir: /usr/lib/x86_64-linux-gnu
 
+
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
 load(
@@ -54,8 +55,6 @@ cc_library(
     srcs = glob([
         "lib/libze_loader.so*",
         "lib/liblevel_zero_utils.a",
-        "lib/libze_null.so*",
-        "lib/libze_tracing_layer.so*",
     ], allow_empty = True),
     data = ([
         "lib/libze_loader.so.1",


### PR DESCRIPTION
This PR adds MKL include paths and required MKL runtime libraries to the oneAPI toolchain configuration, enabling Bazel targets to correctly resolve MKL headers and link against MKL/oneMKL SYCL libraries.