### PR TITLE
Fix aarch64 for CUDA13: add cicc to cuda_nvcc

### DIFF
--- a/cc/impls/linux_aarch64_linux_aarch64_cuda/BUILD
+++ b/cc/impls/linux_aarch64_linux_aarch64_cuda/BUILD
@@ -68,6 +68,7 @@ filegroup(
     srcs = if_cuda([
         "@cuda_nvcc//:bin",
         "@cuda_nvcc//:nvvm",
+        "@cuda_nvvm//:cicc",
     ]),
 )
 


### PR DESCRIPTION
JAX build fails on aarch64 for CUDA13 otherwise