### PR TITLE
[ROCm] Add no_solib_rpath feature

### DIFF
--- a/cc/features/BUILD
+++ b/cc/features/BUILD
@@ -152,6 +152,11 @@ cc_feature(
     enabled = True,
 )
 
+cc_feature(
+    name = "no_solib_rpaths",
+    enabled = False,
+)
+
 #cc_feature(
 #    name = "nobuiltin",
 #    compiler_flags = ["-fno-builtin"],

--- a/third_party/rules_cc_toolchain/toolchain_config.bzl
+++ b/third_party/rules_cc_toolchain/toolchain_config.bzl
@@ -192,7 +192,10 @@ def _get_runtime_library_search_directories_flags():
             ),
         ],
         with_features = [
-            with_feature_set(features = ["static_link_cpp_runtimes"]),
+            with_feature_set(
+                features = ["static_link_cpp_runtimes"],
+                not_features = ["no_solib_rpaths"],
+            ),
         ],
     ),
     flag_set(
@@ -212,7 +215,7 @@ def _get_runtime_library_search_directories_flags():
         ],
         with_features = [
             with_feature_set(
-                not_features = ["static_link_cpp_runtimes"],
+                not_features = ["static_link_cpp_runtimes", "no_solib_rpaths"],
             ),
         ],
     )]


### PR DESCRIPTION
Support no_solib_rpath feature to strip out bazel added solib rpaths when building the release wheels