### PR TITLE
Fix XLA postsubmit CI failure for oneAPI

### DIFF
--- a/gpu/sycl/zero_loader.BUILD
+++ b/gpu/sycl/zero_loader.BUILD
@@ -55,6 +55,7 @@ cc_library(
     srcs = glob([
         "lib/libze_loader.so*",
         "lib/liblevel_zero_utils.a",
+        "lib/libze_tracing_layer.so*",
     ], allow_empty = True),
     data = ([
         "lib/libze_loader.so.1",


### PR DESCRIPTION
XLA postsubmit CI is currently failing due to missing Level Zero runtime artifacts. This PR fixes the issue by including the required Level Zero tracing library in the packaged files.