### PR TITLE
[oneAPI] Make Zero Loader hermetic for XLA and JAX

### DIFF
--- a/gpu/sycl/zero_loader.BUILD
+++ b/gpu/sycl/zero_loader.BUILD
@@ -44,7 +44,9 @@ filegroup(
 cc_toolchain_import(
     name = "libs",
     additional_libs = glob([
-        "**/*",
+        "**/ze_loader.so*",
+        "**/libze_tracing_layer.so*",
+        "**/libze_validation_layer.so*",
     ], allow_empty = True),
     shared_library = "libze_loader.so",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
This PR enables hermetic usage of the oneAPI Zero Loader, allowing XLA and JAX to build in a fully hermetic environment.

The Zero Loader BUILD file is updated to include only the required shared libraries, such as ze_loader, tracing layer, and validation layer libraries, instead of globbing all files.