### PR TITLE
[oneAPI] Fix Bazel test failures by packaging missing oneMKL runtime libraries

### DIFF
--- a/gpu/sycl/oneapi.BUILD.tpl
+++ b/gpu/sycl/oneapi.BUILD.tpl
@@ -355,6 +355,8 @@ cc_library(
             "mkl/{oneapi_version}/lib/libmkl_sycl_lapack.so*".format(oneapi_version = ONEAPI_VERSION),
             "mkl/{oneapi_version}/lib/libmkl_sycl_rng.so*".format(oneapi_version = ONEAPI_VERSION),
             "mkl/{oneapi_version}/lib/libmkl_sycl_sparse.so*".format(oneapi_version = ONEAPI_VERSION),
+            "mkl/{oneapi_version}/lib/libmkl_avx512.so*".format(oneapi_version = ONEAPI_VERSION),
+            "mkl/{oneapi_version}/lib/libmkl_def.so*".format(oneapi_version = ONEAPI_VERSION),
         ],
         allow_empty = True,
     ),


### PR DESCRIPTION
This PR fixes Bazel test failures caused by missing oneMKL runtime libraries in the hermetic oneAPI toolchain.

The issue was observed while running the SparseObjectTest.test_matmul22 test case:

[ RUN ] SparseObjectTest.test_matmul22
(shape=(5, 5), bshape=(5, 3),
Obj=<class 'jax.experimental.sparse.csr.CSR'>,
dtype=<class 'numpy.complex64'>)

The test failed with the following runtime error:

INTEL oneMKL ERROR:
/bazel_cache/execroot/main/bazel-out/k8-opt/bin/tests/sparse_test_gpu.runfiles/main/jaxlib/../_solib_x86_64/_U_A_Aoneapi_S_S_Clibs___Umkl_S2025.1_Slib/libmkl_avx512.so.2:
cannot open shared object file: No such file or directory.

Intel oneMKL FATAL ERROR:
Cannot load libmkl_avx512.so.2 or libmkl_def.so.2.

The failure occurred because the required oneMKL runtime libraries (libmkl_avx512.so.2 and libmkl_def.so.2) were not available in the hermetic oneAPI runtime. This PR updates the hermetic packaging to include the missing oneMKL shared libraries, allowing the runtime to locate the required dependencies and enabling the affected Bazel tests to pass successfully.