### PR TITLE
Include clang-offload-deps in the hermetic oneAPI SYCL toolchain

### DIFF
--- a/cc/impls/linux_x86_64_linux_x86_64_sycl/BUILD
+++ b/cc/impls/linux_x86_64_linux_x86_64_sycl/BUILD
@@ -115,6 +115,7 @@ filegroup(
         "@oneapi//:clang++",
         "@oneapi//:clang-offload-bundler",
         "@oneapi//:clang-offload-wrapper",
+        "@oneapi//:clang-offload-deps",
         "@oneapi//:file-table-tform",
         "@oneapi//:llvm-foreach",
         "@oneapi//:llvm-objcopy",

--- a/gpu/sycl/oneapi.BUILD.tpl
+++ b/gpu/sycl/oneapi.BUILD.tpl
@@ -162,6 +162,13 @@ filegroup(
 )
 
 filegroup(
+    name = "clang-offload-deps",
+    srcs = [
+        "compiler/{oneapi_version}/bin/compiler/clang-offload-deps".format(oneapi_version = ONEAPI_VERSION),
+    ],
+)
+
+filegroup(
     name = "file-table-tform",
     srcs = [
         "compiler/{oneapi_version}/bin/compiler/file-table-tform".format(oneapi_version = ONEAPI_VERSION),
@@ -355,8 +362,6 @@ cc_library(
             "mkl/{oneapi_version}/lib/libmkl_sycl_lapack.so*".format(oneapi_version = ONEAPI_VERSION),
             "mkl/{oneapi_version}/lib/libmkl_sycl_rng.so*".format(oneapi_version = ONEAPI_VERSION),
             "mkl/{oneapi_version}/lib/libmkl_sycl_sparse.so*".format(oneapi_version = ONEAPI_VERSION),
-            "mkl/{oneapi_version}/lib/libmkl_avx512.so*".format(oneapi_version = ONEAPI_VERSION),
-            "mkl/{oneapi_version}/lib/libmkl_def.so*".format(oneapi_version = ONEAPI_VERSION),
         ],
         allow_empty = True,
     ),

--- a/gpu/sycl/oneapi.BUILD.tpl
+++ b/gpu/sycl/oneapi.BUILD.tpl
@@ -355,6 +355,8 @@ cc_library(
             "mkl/{oneapi_version}/lib/libmkl_sycl_lapack.so*".format(oneapi_version = ONEAPI_VERSION),
             "mkl/{oneapi_version}/lib/libmkl_sycl_rng.so*".format(oneapi_version = ONEAPI_VERSION),
             "mkl/{oneapi_version}/lib/libmkl_sycl_sparse.so*".format(oneapi_version = ONEAPI_VERSION),
+            "mkl/{oneapi_version}/lib/libmkl_avx512.so*".format(oneapi_version = ONEAPI_VERSION),
+            "mkl/{oneapi_version}/lib/libmkl_def.so*".format(oneapi_version = ONEAPI_VERSION),
         ],
         allow_empty = True,
     ),


### PR DESCRIPTION
This change adds clang-offload-deps to the hermetic oneAPI SYCL toolchain so it is available during SYCL link actions.
While building //jaxlib/oneapi:_solver.so, the link step failed with:

clang: error: unable to execute command:
Executable "clang-offload-deps" doesn't exist!

It fixes the jax-presubmit failure for oneAPI.