### PR TITLE
Link cudnn_engines_tensor_ir_static when statically linking cuDNN >= 9.21

### DIFF
--- a/gpu/cuda/build_templates/cuda_cudnn.BUILD.tpl
+++ b/gpu/cuda/build_templates/cuda_cudnn.BUILD.tpl
@@ -9,6 +9,7 @@ load(
 load(
      "@local_config_cuda//cuda:build_defs.bzl",
      "if_static_cudnn",
+     "if_version_equal_or_greater_than",
 )
 
 %{multiline_comment}
@@ -89,6 +90,13 @@ cc_import(
 )
 
 cc_import(
+    name = "cudnn_engines_tensor_ir_static",
+    hdrs = [":headers"],
+    static_library = "lib/libcudnn_engines_tensor_ir_static_v%{libcudnn_version}.a",
+    alwayslink = True,
+)
+
+cc_import(
     name = "cudnn_ops_static",
     hdrs = [":headers"],
     static_library = "lib/libcudnn_ops_static_v%{libcudnn_version}.a",
@@ -123,7 +131,11 @@ cc_library(
       %{comment} ":cudnn_heuristic_static",
       %{comment} ":cudnn_graph_static",
       %{comment} ":cudnn_engines_runtime_compiled_static",
-      %{comment}],
+      %{comment}] + if_version_equal_or_greater_than(
+          %{comment}"%{libcudnn_minor_version}",
+          %{comment}"9.21.0",
+          %{comment}[":cudnn_engines_tensor_ir_static"],
+      %{comment}),
       %{comment}["@cuda_cublas//:cublas",
       %{comment}":cudnn_engines_precompiled",
       %{comment}":cudnn_ops",


### PR DESCRIPTION
cuDNN 9.21 ships `lib/libcudnn_engines_tensor_ir_static_v9.a`, and the other static engine archives reference its symbols — statically linked builds against 9.21 fail with unresolved `engines_tensor_ir` symbols without it (hit in Reactant's hermetic CUDA 12.9/cuDNN 9.21 static builds).

This adds the `cc_import` (alwayslink, matching the other engine archives) plus a version-gated entry in the static deps list via `if_version_equal_or_greater_than`. The dynamic side needs no equivalent — #292 removed `cudnn_engines_tensor_ir` from the shared set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD