### PR TITLE
Declare the HIPCC environment variables hipcc_configure reads

### DIFF
--- a/gpu/rocm/hipcc_configure.bzl
+++ b/gpu/rocm/hipcc_configure.bzl
@@ -282,6 +282,12 @@ hipcc_configure = repository_rule(
     environ = [
         "TF_NEED_ROCM",
         "TF_ROCM_AMDGPU_TARGETS",
+        "HIP_CLANG_PATH",
+        "DEVICE_LIB_PATH",
+        "HIP_VDI_HOME",
+        "HIPCC_VERBOSE",
+        "HIPCC_COMPILE_FLAGS_APPEND",
+        "HIPCC_LINK_FLAGS_APPEND",
     ],
     attrs = {
         "rocm_dist": attr.label(


### PR DESCRIPTION
`_hipcc_env` assembles the environment string that the hipcc toolchain feature re-exports to compile actions from `HIP_CLANG_PATH`, `DEVICE_LIB_PATH`, `HIP_VDI_HOME`, `HIPCC_VERBOSE`, `HIPCC_COMPILE_FLAGS_APPEND` and `HIPCC_LINK_FLAGS_APPEND`, but the `repository_rule` only declares `TF_NEED_ROCM` and `TF_ROCM_AMDGPU_TARGETS` in `environ`. Changing any of the undeclared variables — e.g. via `--repo_env` — does not invalidate an already-fetched `@config_rocm_hipcc`, which silently keeps its stale `hipcc_env`. Hit while configuring Reactant's hermetic ROCm builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD