### PR TITLE
Normalize freethreaded Python version kind for rules_python

### DIFF
--- a/py/python_register_toolchain.bzl
+++ b/py/python_register_toolchain.bzl
@@ -45,6 +45,10 @@ def python_register_toolchain(name = "python", python_version = None, **kwargs):
         **kwargs: additional arguments to pass to python_register_toolchains.
     """
 
+    rules_python_version_kind = HERMETIC_PYTHON_VERSION_KIND
+    if rules_python_version_kind == "freethreaded":
+        rules_python_version_kind = "ft"
+
     if python_version:
         python_register_toolchains(
             name = get_toolchain_name_per_python_version(name),
@@ -71,7 +75,7 @@ def python_register_toolchain(name = "python", python_version = None, **kwargs):
             # isnt sufficient to configure freethreaded python toolchain.
             # Because this happens in bazel's phase 2 (build/test) and can fail
             # if init_toolchains runs pip parse during phase1 (fetch).
-            python_version_kind = "ft" if "ft" in HERMETIC_PYTHON_VERSION else HERMETIC_PYTHON_VERSION_KIND,
+            python_version_kind = "ft" if "ft" in HERMETIC_PYTHON_VERSION else rules_python_version_kind,
             tool_versions = {
                 tool_version: {
                     "url": HERMETIC_PYTHON_URL,
@@ -86,5 +90,5 @@ def python_register_toolchain(name = "python", python_version = None, **kwargs):
             name = get_toolchain_name_per_python_version(name),
             ignore_root_user_error = True,
             python_version = HERMETIC_PYTHON_VERSION,
-            python_version_kind = HERMETIC_PYTHON_VERSION_KIND,
+            python_version_kind = rules_python_version_kind,
         )


### PR DESCRIPTION
## Summary

Normalize the hermetic Python version kind from `freethreaded` to `ft` before passing it to `rules_python`.

## Problem

TensorFlow configures the free-threaded hermetic Python version using:
`HERMETIC_PYTHON_VERSION=3.14-freethreaded`

In `py/python_repo.bzl`, `_parse_python_version()` splits this value at `-`, producing:

- `version = "3.14"`
- `kind = "freethreaded"`

That derived kind is then exposed as:

`HERMETIC_PYTHON_VERSION_KIND=freethreaded`

However, `rules_python` expects the corresponding toolchain kind to be:

`python_version_kind="ft"`

In the normal hermetic toolchain registration path, `rules_ml_toolchain` currently forwards the derived `freethreaded` value unchanged.

This prevents correct selection of the free-threaded Python toolchain.

## Fix

Normalize `freethreaded -> ft` before registering the toolchain, while preserving existing behavior for normal Python versions and existing `*-ft` version handling.

## Validation

This issue was reproduced while integrating TensorFlow with Python 3.14 free-threaded.

Using the same normalization locally allowed the hermetic toolchain to resolve the free-threaded interpreter correctly, with:

- `SOABI: cpython-314t-x86_64-linux-gnu`
- `Py_GIL_DISABLED: 1`

TensorFlow was then able to build a `cp314-cp314t` wheel and run with the GIL remaining disabled.

A local Bazel test attempt in this repository did not start because Bazelisk failed to download the Bazel 9.1.0 signature file with HTTP 403, so no test result is claimed here.