### PR TITLE
[oneAPI] Add oneAPI 2026.1 toolchain support

### DIFF
--- a/gpu/sycl/dist_repo.bzl
+++ b/gpu/sycl/dist_repo.bzl
@@ -88,6 +88,20 @@ _ONEAPI_BUILD_SUBSTITUTIONS = {
         "%{umf_version}": "1.1",
         "%{vtune_version}": "2026.0",
     },
+    "2026.1": {
+        "%{advisor_version}": "2026.1",
+        "%{clang_version}": "22",
+        "%{extra_lib_src_glob}": "2026.1/lib/libur_adapter_level_zero_v2.so*",
+        "%{ipp_version}": "2026.0",
+        "%{libsycl_version}": "9",
+        "%{mpi_version}": "2021.18",
+        "%{oneapi_lib_paths}": ":2026.1/lib,:compiler/2026.1/lib,:compiler/2026.1/opt/compiler/lib",
+        "%{oneapi_version}": "2026.1",
+        "%{tbb_version}": "2023.1",
+        "%{tcm_version}": "1.5",
+        "%{umf_version}": "1.1",
+        "%{vtune_version}": "2026.2",
+    },
 }
 
 def _get_build_substitutions(ctx, dist_key):

--- a/gpu/sycl/sycl_redist_versions.bzl
+++ b/gpu/sycl/sycl_redist_versions.bzl
@@ -35,6 +35,16 @@ REDIST_DICT = {
             "1d8633ef69020ecb8f495979c56c6a9db0a3d1343a0697863dcf7fba097a369b",
             "oneapi",
         ],
+        "ubuntu_24.04_2026.0": [
+            "https://d3q76yfpnzmnjx.cloudfront.net/intel-oneapi-base-toolkit-2026.1.0.tar.gz",
+            "0e37f30390d9ae168b0777fa469122af1ebafd04b82cd7301983eeaad7f5848b",
+            "oneapi",
+        ],
+        "ubuntu_24.04_2026.1": [
+            "https://d3q76yfpnzmnjx.cloudfront.net/intel-oneapi-base-toolkit-2026.1.0.tar.gz",
+            "0e37f30390d9ae168b0777fa469122af1ebafd04b82cd7301983eeaad7f5848b",
+            "oneapi",
+        ],
     },
     "level_zero": {
         "ubuntu_24.10_2025.1": [
@@ -47,6 +57,16 @@ REDIST_DICT = {
             "e0ff1c6cb9b551019579a2dd35c3a611240c1b60918c75345faf9514142b9c34",
             "level-zero-1.21.10",
         ],
+        "ubuntu_24.04_2026.0": [
+            "https://d3q76yfpnzmnjx.cloudfront.net/level-zero-1.28.6.tar.gz",
+            "61658892532486018206f74c8839152dfba27b863e5f4edfcba6d8478ac71ad3",
+            "level-zero-1.28.6",
+        ],
+        "ubuntu_24.04_2026.1": [
+            "https://d3q76yfpnzmnjx.cloudfront.net/level-zero-1.28.6.tar.gz",
+            "61658892532486018206f74c8839152dfba27b863e5f4edfcba6d8478ac71ad3",
+            "level-zero-1.28.6",
+        ],
     },
     "zero_loader": {
         "ubuntu_24.10_2025.1": [
@@ -57,6 +77,16 @@ REDIST_DICT = {
         "ubuntu_24.10_2026.0": [
             "https://d3q76yfpnzmnjx.cloudfront.net/ze_loader_libs.tar.gz",
             "71cbfd8ac59e1231f013e827ea8efe6cf5da36fad771da2e75e202423bd6b82e",
+            "",
+        ],
+        "ubuntu_24.04_2026.0": [
+            "https://d3q76yfpnzmnjx.cloudfront.net/ze_loader_libs_1.28.tar.gz",
+            "18c53a79a3aad7264410806f8277459f21485351870495996e3d7b2bf1f188fd",
+            "",
+        ],
+        "ubuntu_24.04_2026.1": [
+            "https://d3q76yfpnzmnjx.cloudfront.net/ze_loader_libs_1.28.tar.gz",
+            "18c53a79a3aad7264410806f8277459f21485351870495996e3d7b2bf1f188fd",
             "",
         ],
     },
@@ -70,6 +100,8 @@ BUILD_TEMPLATES = {
             "ubuntu_24.04_2025.1": "//gpu/sycl:oneapi.BUILD.tpl",
             "ubuntu_22.04_2025.1": "//gpu/sycl:oneapi.BUILD.tpl",
             "ubuntu_24.10_2026.0": "//gpu/sycl:oneapi.BUILD.tpl",
+            "ubuntu_24.04_2026.0": "//gpu/sycl:oneapi.BUILD.tpl",
+            "ubuntu_24.04_2026.1": "//gpu/sycl:oneapi.BUILD.tpl",
         },
     },
     "level_zero": {
@@ -77,6 +109,8 @@ BUILD_TEMPLATES = {
         "version_to_template": {
             "ubuntu_24.10_2025.1": "//gpu/sycl:level_zero.BUILD",
             "ubuntu_24.10_2026.0": "//gpu/sycl:level_zero.BUILD",
+            "ubuntu_24.04_2026.0": "//gpu/sycl:level_zero.BUILD",
+            "ubuntu_24.04_2026.1": "//gpu/sycl:level_zero.BUILD",
         },
     },
     "zero_loader": {
@@ -84,6 +118,8 @@ BUILD_TEMPLATES = {
         "version_to_template": {
             "ubuntu_24.10_2025.1": "//gpu/sycl:zero_loader.BUILD",
             "ubuntu_24.10_2026.0": "//gpu/sycl:zero_loader.BUILD",
+            "ubuntu_24.04_2026.0": "//gpu/sycl:zero_loader.BUILD",
+            "ubuntu_24.04_2026.1": "//gpu/sycl:zero_loader.BUILD",
         },
     },
 }


### PR DESCRIPTION
This PR adds Ubuntu 24.04 redist and build configuration for oneAPI 2026.1, including Clang 22, Level Zero 1.28.6, and updated SYCL library paths.