### PR TITLE
[oneAPI] Fix SYCL dependency selection for GPU builds

### DIFF
--- a/gpu/sycl/build_defs.bzl.tpl
+++ b/gpu/sycl/build_defs.bzl.tpl
@@ -40,15 +40,15 @@ def sycl_build_is_configured():
     """Returns true if SYCL compiler was enabled during the configure process."""
     return %{sycl_build_is_configured}
 
-def if_sycl_is_configured(x):
+def if_sycl_is_configured(x, no_sycl = []):
     """Tests if the SYCL was enabled during the configure process.
 
     Unlike if_sycl(), this does not require that we are building with
     --config=sycl. Used to allow non-SYCL code to depend on SYCL libraries.
     """
     if %{sycl_is_configured}:
-      return select({"//conditions:default": x})
-    return select({"//conditions:default": []})
+      return x
+    return no_sycl
 
 def if_sycl_build_is_configured(if_true, if_false = []):
     if sycl_build_is_configured():


### PR DESCRIPTION
Update if_sycl_is_configured() to return a plain list instead of a single-branch select. This fixes nested select type errors when combining SYCL dependencies with other GPU backends and allows JAX to conditionally include oneAPI dependencies instead of adding them unconditionally.