### PR TITLE
Don't drop libraries with only linker flags in pywrap rules

### DIFF
--- a/py/rules_pywrap/pywrap.impl.bzl
+++ b/py/rules_pywrap/pywrap.impl.bzl
@@ -709,7 +709,19 @@ def _linker_input_filters_impl(ctx):
     for filter, name in ctx.attr.common_lib_filters.items():
         filter_li = filter[CcInfo].linking_context.linker_inputs.to_list()
         for li in filter_li:
-            if li not in visited_filters:
+            # Linker inputs without object code (e.g. link flags from TF_SYSTEM_LIBS)
+            # may be shared by multiple libraries.
+            # Otherwise the first filter claiming them would leave the others without
+            # e.g. the necessary `l` flags.
+            flags_only = all([
+                not (lib.objects
+                     or lib.static_library
+                     or lib.pic_static_library
+                     or lib.dynamic_library
+                     or lib.interface_library)
+                for lib in li.libraries
+            ])
+            if flags_only or li not in visited_filters:
                 common_lib_filters[name][li] = li.owner
                 visited_filters[li] = li.owner
 


### PR DESCRIPTION
Linker inputs without object code (e.g. link flags from TF_SYSTEM_LIBS containing only `-lfoo`) must not be filtered or they will be claimed by the first match and missing from subsequent linker steps leading to missing symbols.

See https://github.com/tensorflow/tensorflow/issues/126093 and https://github.com/tensorflow/tensorflow/pull/126112#issuecomment-5422763419 for more details