### PR TITLE
[oneAPI] Revert AVX512 changes- #29

### DIFF
--- a/gpu/sycl/oneapi.BUILD.tpl
+++ b/gpu/sycl/oneapi.BUILD.tpl
@@ -362,8 +362,6 @@ cc_library(
             "mkl/{oneapi_version}/lib/libmkl_sycl_lapack.so*".format(oneapi_version = ONEAPI_VERSION),
             "mkl/{oneapi_version}/lib/libmkl_sycl_rng.so*".format(oneapi_version = ONEAPI_VERSION),
             "mkl/{oneapi_version}/lib/libmkl_sycl_sparse.so*".format(oneapi_version = ONEAPI_VERSION),
-            "mkl/{oneapi_version}/lib/libmkl_avx512.so*".format(oneapi_version = ONEAPI_VERSION),
-            "mkl/{oneapi_version}/lib/libmkl_def.so*".format(oneapi_version = ONEAPI_VERSION),
         ],
         allow_empty = True,
     ),

--- a/gpu/sycl/sycl_redist_versions.bzl
+++ b/gpu/sycl/sycl_redist_versions.bzl
@@ -36,8 +36,8 @@ REDIST_DICT = {
             "oneapi",
         ],
         "ubuntu_24.04_2026.0": [
-            "https://d3q76yfpnzmnjx.cloudfront.net/intel-oneapi-base-toolkit-2026.1.0.tar.gz",
-            "0e37f30390d9ae168b0777fa469122af1ebafd04b82cd7301983eeaad7f5848b",
+            "https://d3q76yfpnzmnjx.cloudfront.net/intel-oneapi-base-toolkit-2026.0.0.tar.gz",
+            "1d8633ef69020ecb8f495979c56c6a9db0a3d1343a0697863dcf7fba097a369b",
             "oneapi",
         ],
         "ubuntu_24.04_2026.1": [


### PR DESCRIPTION
This PR reverts the AVX-512 changes for now. We will reintroduce them once extensive testing has been completed on both AVX-512 and non-AVX-512 machines.

This PR also fixes a minor oneAPI Base Toolkit version change that was previously applied in the wrong location.