### PR TITLE
[ROCm] Add global symbol version linker script to avoid llvm symbol clashes …

### DIFF
--- a/cc/impls/linux_x86_64_linux_x86_64_rocm/BUILD
+++ b/cc/impls/linux_x86_64_linux_x86_64_rocm/BUILD
@@ -248,6 +248,7 @@ FEATURES_ESSENTIAL = [
     "//cc/rocm/features:rocm_hermetic",
     "//cc/rocm/features:rocm_warnings",
     "//cc/rocm/features:rocm_compiler_rt",
+    "//cc/rocm/features:rocm_global_symbol_version_script",
     "//cc/features:no_solib_rpaths",
     "//cc/features:runtime_library_search_directories",
 

--- a/cc/rocm/features/BUILD
+++ b/cc/rocm/features/BUILD
@@ -24,9 +24,9 @@ load(":rocm_global_symbol_version_script_feature.bzl", "rocm_global_symbol_versi
 package(default_visibility = ["//visibility:public"])
 
 config_setting(
-    name = "is_rocm_global_symbol_version_enabled",
+    name = "is_xla_test_global_symbol_version_enabled",
     flag_values = {
-        "//common:enable_rocm_global_symbol_version": "True",
+        "//common:enable_xla_test_global_symbol_version": "True",
     },
 )
 
@@ -75,11 +75,11 @@ cc_feature(
 
 # ROCm global symbol versioning
 # Controls symbol visibility using a linker version script
-# Can be enabled with --@rules_ml_toolchain//common:enable_rocm_global_symbol_version=True
+# Can be enabled with --@rules_ml_toolchain//common:enable_xla_test_global_symbol_version=True
 rocm_global_symbol_version_script_feature(
     name = "rocm_global_symbol_version_script",
     enabled = select({
-        "//cc/rocm/features:is_rocm_global_symbol_version_enabled": True,
+        "//cc/rocm/features:is_xla_test_global_symbol_version_enabled": True,
         "//conditions:default": False,
     }),
     version_script = ":global_symbol_version_script",

--- a/cc/rocm/features/BUILD
+++ b/cc/rocm/features/BUILD
@@ -19,8 +19,21 @@ load(
     "//third_party/rules_cc_toolchain/features:features.bzl",
     "cc_feature",
 )
+load(":rocm_global_symbol_version_script_feature.bzl", "rocm_global_symbol_version_script_feature")
 
 package(default_visibility = ["//visibility:public"])
+
+config_setting(
+    name = "is_rocm_global_symbol_version_enabled",
+    flag_values = {
+        "//common:enable_rocm_global_symbol_version": "True",
+    },
+)
+
+filegroup(
+    name = "global_symbol_version_script",
+    srcs = ["global_symbol_version.lds"],
+)
 
 # ROCm-specific preprocessor definitions
 cc_feature(
@@ -60,4 +73,15 @@ cc_feature(
     linker_flags = ["-rtlib=compiler-rt"],
 )
 
-
+# ROCm global symbol versioning
+# Controls symbol visibility using a linker version script
+# Can be enabled with --@rules_ml_toolchain//common:enable_rocm_global_symbol_version=True
+rocm_global_symbol_version_script_feature(
+    name = "rocm_global_symbol_version_script",
+    enabled = select({
+        "//cc/rocm/features:is_rocm_global_symbol_version_enabled": True,
+        "//conditions:default": False,
+    }),
+    version_script = ":global_symbol_version_script",
+    visibility = ["//visibility:public"],
+)

--- a/cc/rocm/features/global_symbol_version.lds
+++ b/cc/rocm/features/global_symbol_version.lds
@@ -1,0 +1,6 @@
+# Assign a symbol version to every exported symbol.
+# This is the cheapest option to make sure exported
+# llvm symbols don't clash with those of ROCm's libLLVM.so
+XLA_TEST {
+  global: *;
+};

--- a/cc/rocm/features/rocm_global_symbol_version_script_feature.bzl
+++ b/cc/rocm/features/rocm_global_symbol_version_script_feature.bzl
@@ -1,0 +1,82 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""ROCm global symbol version script feature rule."""
+
+load(
+    "@rules_cc//cc:action_names.bzl",
+    "ACTION_NAME_GROUPS",
+)
+load(
+    "@rules_cc//cc:cc_toolchain_config_lib.bzl",
+    "FeatureInfo",
+    "flag_group",
+    "flag_set",
+    _feature = "feature",
+)
+
+def _rocm_global_symbol_version_script_feature_impl(ctx):
+    """Implementation of the rocm_global_symbol_version_script_feature rule."""
+
+    # Get the path from the label
+    version_script_file = ctx.file.version_script
+    version_script_path = version_script_file.path
+
+    return _feature(
+        name = ctx.label.name,
+        enabled = ctx.attr.enabled,
+        flag_sets = [
+            flag_set(
+                actions = ACTION_NAME_GROUPS.all_cc_link_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = ["-Wl,--version-script," + version_script_path],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+rocm_global_symbol_version_script_feature = rule(
+    implementation = _rocm_global_symbol_version_script_feature_impl,
+    attrs = {
+        "enabled": attr.bool(
+            default = True,
+            doc = "Whether this feature is enabled by default.",
+        ),
+        "version_script": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+            doc = "Label pointing to the global symbol version script file.",
+        ),
+    },
+    provides = [FeatureInfo],
+    doc = """
+Creates a toolchain feature for ROCm global symbol versioning.
+
+This feature adds a linker version script to prevent LLVM symbol clashes
+between XLA's LLVM and ROCm's libLLVM.so.
+
+Example usage:
+    rocm_global_symbol_version_script_feature(
+        name = "rocm_global_symbol_version_script",
+        version_script = "@config_rocm_hipcc//rocm:global_symbol_version.lds",
+        enabled = select({
+            "//common:is_rocm_global_symbol_version_enabled": True,
+            "//conditions:default": False,
+        }),
+    )
+""",
+)

--- a/common/BUILD
+++ b/common/BUILD
@@ -265,6 +265,13 @@ bool_flag(
     build_setting_default = False,
 )
 
+# Enable ROCm global symbol versioning
+# Prevents LLVM symbol clashes between XLA's LLVM and ROCm's libLLVM.so
+bool_flag(
+    name = "enable_rocm_global_symbol_version",
+    build_setting_default = False,
+)
+
 config_setting(
     name = "is_rocm_enabled",
     flag_values = {
@@ -278,6 +285,7 @@ config_setting(
         ":enable_rocm": "False",
     },
 )
+
 
 #######################################################
 # Sanitizers flags

--- a/common/BUILD
+++ b/common/BUILD
@@ -265,10 +265,10 @@ bool_flag(
     build_setting_default = False,
 )
 
-# Enable ROCm global symbol versioning
+# Enable XLA_TEST global symbol versioning
 # Prevents LLVM symbol clashes between XLA's LLVM and ROCm's libLLVM.so
 bool_flag(
-    name = "enable_rocm_global_symbol_version",
+    name = "enable_xla_test_global_symbol_version",
     build_setting_default = False,
 )
 


### PR DESCRIPTION
When using dynamic_mode=fully (useful for our CI builds and cache friendly)
we got symbol clashes with the internal rocm llvm symbols. This change
adds a new feature that applies a symbol version to symbols from inside the xla build
this avoid clashes with the prebuilt rocm libs which are using a different version of llvm